### PR TITLE
feat(discord.js-utilities): verify channel type before removing reaction & allow page prompt customization

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -77,6 +77,12 @@ export class PaginatedMessage {
 	public idle = 20 * 1000;
 
 	/**
+	 * Custom prompt message when a user wants to jump to a certain page number.
+	 * @default What page would you like to jump to
+	 */
+	public static promptMessage = 'What page would you like to jump to?';
+
+	/**
 	 * Constructor for the {@link PaginatedMessage} class
 	 * @param __namedParameters The {@link PaginatedMessageOptions} for this instance of the {@link PaginatedMessage} class
 	 */
@@ -85,6 +91,11 @@ export class PaginatedMessage {
 
 		for (const page of this.pages) this.messages.push(page instanceof APIMessage ? page : null);
 		for (const action of actions ?? this.constructor.defaultActions) this.actions.set(action.id, action);
+	}
+
+	public setPromptMessage(message: string) {
+		PaginatedMessage.promptMessage = message;
+		return this;
 	}
 
 	/**
@@ -315,7 +326,7 @@ export class PaginatedMessage {
 		{
 			id: '🔢',
 			run: async ({ handler, author, channel }) => {
-				const questionMessage = await channel.send('What page would you like to jump to?');
+				const questionMessage = await channel.send(PaginatedMessage.promptMessage);
 				const collected = await channel
 					.awaitMessages((message: Message) => message.author.id === author.id, { max: 1, idle: 15 * 1000 })
 					.catch(() => null);

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -314,7 +314,7 @@ export class PaginatedMessage {
 
 		// Do not remove reactions if the message, channel, or guild, was deleted:
 		if (this.response && !PaginatedMessage.deletionStopReasons.includes(reason)) {
-			if (isGuildBasedChannel(this.response.channel) && this.response.channel.permissionsFor(this.response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+			if (isGuildBasedChannel(this.response.channel) && this.response.client.user && this.response.channel.permissionsFor(this.response.client.user.id)?.has('MANAGE_MESSAGES')) {
 				await this.response.reactions.removeAll();
 			}
 		}
@@ -371,7 +371,7 @@ export class PaginatedMessage {
 		{
 			id: '⏹️',
 			run: async ({ response, collector }) => {
-				if (isGuildBasedChannel(response.channel) && response.channel.permissionsFor(response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+				if (isGuildBasedChannel(response.channel) && response.client.user && response.channel.permissionsFor(response.client.user.id)?.has('MANAGE_MESSAGES')) {
 					await response.reactions.removeAll();
 				}
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -283,7 +283,7 @@ export class PaginatedMessage {
 	 * @param user The user that reacted to the message.
 	 */
 	protected async handleCollect(author: User, channel: TextChannel | NewsChannel, reaction: MessageReaction, user: User): Promise<void> {
-		if ((channel as TextChannel).permissionsFor(channel.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+		if (isGuildBasedChannel(channel) && channel.client.user && channel.permissionsFor(channel.client.user.id).has('MANAGE_MESSAGES')) {
 			await reaction.users.remove(user);
 		}
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -272,7 +272,9 @@ export class PaginatedMessage {
 	 * @param user The user that reacted to the message.
 	 */
 	protected async handleCollect(author: User, channel: TextChannel | NewsChannel, reaction: MessageReaction, user: User): Promise<void> {
-		await reaction.users.remove(user);
+		if ((channel as TextChannel).permissionsFor(channel.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+			await reaction.users.remove(user);
+		}
 
 		const action = (this.actions.get(reaction.emoji.identifier) ?? this.actions.get(reaction.emoji.name))!;
 		const previousIndex = this.index;
@@ -300,7 +302,9 @@ export class PaginatedMessage {
 
 		// Do not remove reactions if the message, channel, or guild, was deleted:
 		if (this.response && !PaginatedMessage.deletionStopReasons.includes(reason)) {
-			await this.response.reactions.removeAll();
+			if ((this.response.channel as TextChannel).permissionsFor(this.response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+				await this.response.reactions.removeAll();
+			}
 		}
 	}
 
@@ -355,7 +359,10 @@ export class PaginatedMessage {
 		{
 			id: '⏹️',
 			run: async ({ response, collector }) => {
-				await response.reactions.removeAll();
+				if ((response.channel as TextChannel).permissionsFor(response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+					await response.reactions.removeAll();
+				}
+
 				collector.stop();
 			}
 		}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -284,7 +284,7 @@ export class PaginatedMessage {
 	 * @param user The user that reacted to the message.
 	 */
 	protected async handleCollect(author: User, channel: TextChannel | NewsChannel, reaction: MessageReaction, user: User): Promise<void> {
-		if (isGuildBasedChannel(channel) && channel.client.user && channel.permissionsFor(channel.client.user.id)) {
+		if (isGuildBasedChannel(channel) && channel.client.user && channel.permissionsFor(channel.client.user.id)?.has('MANAGE_MESSAGES')) {
 			await reaction.users.remove(user);
 		}
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -78,7 +78,7 @@ export class PaginatedMessage {
 
 	/**
 	 * Custom prompt message when a user wants to jump to a certain page number.
-	 * @default What page would you like to jump to
+	 * @default "What page would you like to jump to?"
 	 */
 	public static promptMessage = 'What page would you like to jump to?';
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -1,4 +1,5 @@
 import { APIMessage, Message, MessageOptions, MessageReaction, NewsChannel, ReactionCollector, TextChannel, User } from 'discord.js';
+import { isGuildBasedChannel } from './type-guards';
 
 /**
  * This is a {@link PaginatedMessage}, a utility to paginate messages (usually embeds).
@@ -283,7 +284,7 @@ export class PaginatedMessage {
 	 * @param user The user that reacted to the message.
 	 */
 	protected async handleCollect(author: User, channel: TextChannel | NewsChannel, reaction: MessageReaction, user: User): Promise<void> {
-		if (isGuildBasedChannel(channel) && channel.client.user && channel.permissionsFor(channel.client.user.id).has('MANAGE_MESSAGES')) {
+		if (isGuildBasedChannel(channel) && channel.client.user && channel.permissionsFor(channel.client.user.id)) {
 			await reaction.users.remove(user);
 		}
 
@@ -313,7 +314,7 @@ export class PaginatedMessage {
 
 		// Do not remove reactions if the message, channel, or guild, was deleted:
 		if (this.response && !PaginatedMessage.deletionStopReasons.includes(reason)) {
-			if ((this.response.channel as TextChannel).permissionsFor(this.response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+			if (isGuildBasedChannel(this.response.channel) && this.response.channel.permissionsFor(this.response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
 				await this.response.reactions.removeAll();
 			}
 		}
@@ -370,7 +371,7 @@ export class PaginatedMessage {
 		{
 			id: '⏹️',
 			run: async ({ response, collector }) => {
-				if ((response.channel as TextChannel).permissionsFor(response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
+				if (isGuildBasedChannel(response.channel) && response.channel.permissionsFor(response.client.user?.id || '')?.has('MANAGE_MESSAGES')) {
 					await response.reactions.removeAll();
 				}
 


### PR DESCRIPTION
### Changes made
1. permission to manage messages is now optional for the pager. This has no negative effect on the `ReactionCollector` of `discord.js`.
2. It is now possible to customize the `jump prompt message` to a certain page number so that the user can choose a certain message. This is because not all bots are in English language and this allows more customization.