### PR TITLE
feat(discord.js-utilities): improve PaginatedMessage

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -45,9 +45,10 @@ jobs:
         run: |
           # Resolve the tag to be used. "next" for push events, "pr-{prNumber}" for dispatch events.
           TAG=$([[ ${{ github.event_name }} == 'push' ]] && echo 'next' || echo 'pr-${{ github.event.inputs.prNumber }}')
+          BRANCH=$(echo '${{ github.event.ref }}' | sed 's/refs\/heads\///g')
 
           # Bump and publish
-          yarn lerna publish --yes --conventional-prerelease --ignore-scripts --no-verify-access --no-git-tag-version --no-push --pre-dist-tag next --preid "${TAG}.$(git rev-parse --verify --short HEAD)"
+          yarn lerna publish --yes --conventional-prerelease --ignore-scripts --no-verify-access --no-git-tag-version --no-push --pre-dist-tag ${TAG} --preid "${TAG}.$(git rev-parse --verify --short HEAD)" --allow-branch ${BRANCH}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install Dependencies if Cache Miss
         if: ${{ !steps.cache-restore.outputs.cache-hit }}
         run: yarn --frozen-lockfile
-      - name: Build ESLint and Prettier configs
-        run: yarn tsc -b packages/eslint-config packages/prettier-config
+      - name: Build ESLint, Prettier and Utilities
+        run: yarn build:1
       - name: Run ESLint
         run: yarn lint --fix=false
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.28.2",
 		"@typescript-eslint/parser": "^4.28.0",
 		"cz-conventional-changelog": "^3.3.0",
+		"discord-api-types": "^0.18.1",
 		"discord.js": "^12.5.3",
 		"eslint": "^7.30.0",
 		"eslint-config-prettier": "^8.3.0",

--- a/packages/discord.js-utilities/package.json
+++ b/packages/discord.js-utilities/package.json
@@ -50,6 +50,8 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@sapphire/discord-utilities": "^2.1.5"
+		"@sapphire/discord-utilities": "^2.1.5",
+		"@sapphire/utilities": "^2.0.0",
+		"@sapphire/time-utilities": "^1.3.7"
 	}
 }

--- a/packages/discord.js-utilities/rollup.config.js
+++ b/packages/discord.js-utilities/rollup.config.js
@@ -1,3 +1,7 @@
 import baseConfig from '../../scripts/rollup.config';
 
-export default baseConfig({ extraOptions: { external: ['@sapphire/discord-utilities', 'discord.js'] } });
+export default baseConfig({
+	extraOptions: {
+		external: ['@sapphire/discord-utilities', '@sapphire/time-utilities', '@sapphire/utilities', 'discord.js']
+	}
+});

--- a/packages/discord.js-utilities/src/index.ts
+++ b/packages/discord.js-utilities/src/index.ts
@@ -1,6 +1,5 @@
 export * from '@sapphire/discord-utilities';
 export * from './lib/builders/MessageBuilder';
-export * from './lib/LazyPaginatedMessage';
 export * from './lib/MessagePrompter';
-export * from './lib/PaginatedMessage';
+export * from './lib/PaginatedMessages';
 export * from './lib/type-guards';

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -1,4 +1,6 @@
-import type { APIMessage, NewsChannel, TextChannel } from 'discord.js';
+import { isFunction } from '@sapphire/utilities';
+import { APIMessage, Message, MessageEmbed } from 'discord.js';
+import { MessageBuilder } from '../builders/MessageBuilder';
 import { PaginatedMessage } from './PaginatedMessage';
 
 /**
@@ -8,7 +10,7 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 	/**
 	 * Only resolves the page corresponding with the handler's current index.
 	 */
-	public async resolvePagesOnRun(channel: TextChannel | NewsChannel): Promise<void> {
+	public override async resolvePagesOnRun(channel: Message['channel']): Promise<void> {
 		await this.resolvePage(channel, this.index);
 	}
 
@@ -16,12 +18,24 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 	 * Resolves the page corresponding with the given index. This also resolves the index's before and after the given index.
 	 * @param index The index to resolve. Defaults to handler's current index.
 	 */
-	public async resolvePage(channel: TextChannel | NewsChannel, index: number): Promise<APIMessage> {
+	public override async resolvePage(channel: Message['channel'], index: number): Promise<APIMessage> {
 		const promises = [super.resolvePage(channel, index)];
 		if (this.hasPage(index - 1)) promises.push(super.resolvePage(channel, index - 1));
 		if (this.hasPage(index + 1)) promises.push(super.resolvePage(channel, index + 1));
 
 		const [result] = await Promise.all(promises);
 		return result;
+	}
+
+	public override addPageBuilder(builder: MessageBuilder | ((builder: MessageBuilder) => MessageBuilder)): this {
+		return this.addPage(() => (isFunction(builder) ? builder(new MessageBuilder()) : builder));
+	}
+
+	public override addPageContent(content: string): this {
+		return this.addPage(() => ({ content }));
+	}
+
+	public override addPageEmbed(cb: MessageEmbed | ((builder: MessageEmbed) => MessageEmbed)): this {
+		return this.addPage(() => ({ embed: typeof cb === 'function' ? cb(new MessageEmbed()) : cb }));
 	}
 }

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/index.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/index.ts
@@ -1,0 +1,2 @@
+export * from './LazyPaginatedMessage';
+export * from './PaginatedMessage';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,6 +1652,16 @@
     psl "^1.8.0"
     tslib "^2.3.0"
 
+"@sapphire/ratelimits@^1.2.1":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@sapphire/ratelimits/-/ratelimits-1.2.5.tgz#61e8e72c7ec37c67b958fcb324c892673dc68197"
+  integrity sha512-X/yQPgTqCerZuQokivQE2d+waW5shemZWrH/b4elWTFPWpp3PMJTqfvFQxcYi8z8WjnUzL9vESh7czbvW/mpuA==
+
+"@sapphire/utilities@^1.5.1":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/utilities/-/utilities-1.7.0.tgz#b40adc0f092ce988232da3879c68d0ee17ee8908"
+  integrity sha512-+bU6rGr529oj1RoK31aHkBoLYnEqawRwwwUMSRPeaZx21gPrvqjJgwyBBMPEWTv2kjRSyzTTVtV7U0bkZ2RMjQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -3183,6 +3193,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+discord-api-types@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.18.1.tgz#5d08ed1263236be9c21a22065d0e6b51f790f492"
+  integrity sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==
 
 discord.js@^12.5.3:
   version "12.5.3"


### PR DESCRIPTION
### Features

* **discord.js-utilities:** Added TSDoc for many methods
* **discord.js-utilities:** Added caching of messages and handlers to improve performance
* **discord.js-utilities:** Added `addPageBuilder` helper method to make adding pages easier
* **discord.js-utilities:** Added `addPageContent` helper method to make adding pages easier
* **discord.js-utilities:** Added `addPageEmbed` helper method to make adding pages easier
* **discord.js-utilities:** Added `addAsyncPageEmbed` helper method to make adding pages easier. This method is unique from `addPageEmbed` in that the callback can return a `Promise`.
* **discord.js-utilities:** Added `addAsyncPageBuilder` helper method to make adding pages easier. This method is unique from `addPageBuilder` in that the callback can return a `Promise`.
* **discord.js-utilities:** Added `PaginatedMessageOptions.template` to create template `MessageOptions` that apply to all pages
* **discord.js-utilities:** Refactored `PaginatedMessage.setUpReactions` to only add reactions if more than 1 page was added
* **discord.js-utilities:** Refactored to use `@sapphire/time-utilities` and `@sapphire/utilities` instead of duplicating code

### ⚠ BREAKING CHANGES

* **discord.js-utilities:** `PaginatedMessageOptions.run` now takes a single parameter of `Message` instead of 2 parameters (`User` and `TextChannel | NewsChannel`)
* **discord.js-utilities:** Reactions will no longer be added if your `PaginatedMessage` only has 1 page
* **discord.js-utilities:** TypeScript types for various methods that previously had `TextChannel | NewsChannel` have been changed to `Message['channel']`
* **discord.js-utilities:** 1 user can no longer have more than 1 `PaginatedMessage` running. The older one will automatically be cancelled. You can override this by overriding the `run` method.
