### PR TITLE
feat(decorators): add user permissions decorator

### DIFF
--- a/packages/decorators/src/djs-decorators.ts
+++ b/packages/decorators/src/djs-decorators.ts
@@ -65,7 +65,10 @@ export const RequiresPermissions = (...permissionsResolvable: PermissionResolvab
 
 	return createFunctionPrecondition((message: Message) => {
 		if (isDMChannel(message.channel) && resolvedIncludesServerPermissions) {
-			throw new UserError({ identifier: DecoratorIdentifiers.RequiresPermissionsGuildOnly });
+			throw new UserError({
+				identifier: DecoratorIdentifiers.RequiresPermissionsGuildOnly,
+				message: 'Sorry but that command can only be used in a server because I do not have sufficient permissions in DMs'
+			});
 		}
 
 		if (isGuildBasedChannel(message.channel)) {
@@ -74,6 +77,7 @@ export const RequiresPermissions = (...permissionsResolvable: PermissionResolvab
 			if (missingPermissions.length) {
 				throw new UserError({
 					identifier: DecoratorIdentifiers.RequiresPermissionsMissingPermissions,
+					message: `Sorry, but I am not allowed to do that. I am missing the permissions: ${missingPermissions}`,
 					context: {
 						missing: missingPermissions
 					}

--- a/packages/decorators/src/djs-decorators.ts
+++ b/packages/decorators/src/djs-decorators.ts
@@ -4,8 +4,10 @@ import { Message, PermissionResolvable, Permissions } from 'discord.js';
 import { createFunctionPrecondition, FunctionFallback } from './utils';
 
 export const enum DecoratorIdentifiers {
-	RequiresPermissionsGuildOnly = 'requiresPermissionsGuildOnly',
-	RequiresPermissionsMissingPermissions = 'requiresPermissionsMissingPermissions'
+	RequiresClientPermissionsGuildOnly = 'requiresClientPermissionsGuildOnly',
+	RequiresClientPermissionsMissingPermissions = 'requiresClientPermissionsMissingPermissions',
+	RequiresUserPermissionsGuildOnly = 'requiresUserPermissionsGuildOnly',
+	RequiresUserPermissionsMissingPermissions = 'requiresUserPermissionsMissingPermissions'
 }
 
 const DMAvailablePermissions = new Permissions(
@@ -21,13 +23,28 @@ const DMAvailablePermissions = new Permissions(
 	]).bitfield & Permissions.ALL
 );
 
+const DMAvailableUserPermissions = new Permissions(
+	~new Permissions([
+		'ADD_REACTIONS',
+		'ATTACH_FILES',
+		'EMBED_LINKS',
+		'READ_MESSAGE_HISTORY',
+		'SEND_MESSAGES',
+		'USE_EXTERNAL_EMOJIS',
+		'VIEW_CHANNEL',
+		'USE_EXTERNAL_STICKERS',
+		'MENTION_EVERYONE'
+	]).bitfield & Permissions.ALL
+);
+
 /**
  * Allows you to set permissions required for individual methods. This is particularly useful for subcommands that require specific permissions.
+ * @remark This decorator applies to the client that is to execute the command. For setting permissions required user of the command see {@link RequiresUserPermissions}
  * @remark This decorator makes the decorated function asynchronous, so any result should be `await`ed.
  * @param permissionsResolvable Permissions that the method should have.
  * @example
  * ```typescript
- * import { ApplyOptions, RequiresPermissions } from '@sapphire/decorators';
+ * import { ApplyOptions, RequiresClientPermissions } from '@sapphire/decorators';
  * import { SubCommandPluginCommand, SubCommandPluginCommandOptions } from '@sapphire/plugin-subcommands';
  * import type { Message } from 'discord.js';
  *
@@ -42,42 +59,111 @@ const DMAvailablePermissions = new Permissions(
  * 		return message.channel.send('Showing!');
  * 	}
  *
- * 	(at)RequiresPermissions('BAN_MEMBERS') // This subcommand should only be available to "staff".
+ * 	(at)RequiresClientPermissions('BAN_MEMBERS') // This subcommand requires the client to be able to ban members.
  * 	public async add(message: Message) {
  * 		return message.channel.send('Adding!');
  * 	}
  *
- * 	(at)RequiresPermissions('BAN_MEMBERS') // This subcommand should only be available to "staff".
+ * 	(at)RequiresClientPermissions('BAN_MEMBERS') // This subcommand requires the client to be able to ban members.
  * 	public async remove(message: Message) {
  * 		return message.channel.send('Removing!');
  * 	}
  *
- * 	(at)RequiresPermissions('BAN_MEMBERS') // This subcommand should only be available to "staff".
+ * 	(at)RequiresClientPermissions('BAN_MEMBERS') // This subcommand requires the client to be able to ban members.
  * 	public async reset(message: Message) {
  * 		return message.channel.send('Resetting!');
  * 	}
  * }
  * ```
  */
-export const RequiresPermissions = (...permissionsResolvable: PermissionResolvable[]): MethodDecorator => {
+export const RequiresClientPermissions = (...permissionsResolvable: PermissionResolvable[]): MethodDecorator => {
 	const resolved = new Permissions(permissionsResolvable);
 	const resolvedIncludesServerPermissions = Boolean(resolved.bitfield & DMAvailablePermissions.bitfield);
 
 	return createFunctionPrecondition((message: Message) => {
-		if (isDMChannel(message.channel) && resolvedIncludesServerPermissions) {
+		if (resolvedIncludesServerPermissions && isDMChannel(message.channel)) {
 			throw new UserError({
-				identifier: DecoratorIdentifiers.RequiresPermissionsGuildOnly,
+				identifier: DecoratorIdentifiers.RequiresClientPermissionsGuildOnly,
 				message: 'Sorry but that command can only be used in a server because I do not have sufficient permissions in DMs'
 			});
 		}
 
 		if (isGuildBasedChannel(message.channel)) {
-			const missingPermissions = message.channel.permissionsFor(message.guild!.me!)!.missing(resolved);
+			const missingPermissions = message.channel.permissionsFor(message.guild!.me!).missing(resolved);
 
 			if (missingPermissions.length) {
 				throw new UserError({
-					identifier: DecoratorIdentifiers.RequiresPermissionsMissingPermissions,
+					identifier: DecoratorIdentifiers.RequiresClientPermissionsMissingPermissions,
 					message: `Sorry, but I am not allowed to do that. I am missing the permissions: ${missingPermissions}`,
+					context: {
+						missing: missingPermissions
+					}
+				});
+			}
+		}
+
+		return true;
+	});
+};
+
+/**
+ * Allows you to set permissions required for individual methods. This is particularly useful for subcommands that require specific permissions.
+ * @remark This decorator applies to the user of the command. For setting permissions required for the client see {@link RequiresClientPermissions}
+ * @remark This decorator makes the decorated function asynchronous, so any result should be `await`ed.
+ * @param permissionsResolvable Permissions that the method should have.
+ * @example
+ * ```typescript
+ * import { ApplyOptions, RequiresUserPermissions } from '@sapphire/decorators';
+ * import { SubCommandPluginCommand, SubCommandPluginCommandOptions } from '@sapphire/plugin-subcommands';
+ * import type { Message } from 'discord.js';
+ *
+ * (at)ApplyOptions<SubCommandPluginCommandOptions>({
+ * 	aliases: ['cws'],
+ * 	description: 'A basic command with some subcommands',
+ * 	subCommands: ['add', 'remove', 'reset', { input: 'show', default: true }]
+ * })
+ * export default class extends SubCommandPluginCommand {
+ *     // Anyone should be able to view the result, but not modify
+ * 	public async show(message: Message) {
+ * 		return message.channel.send('Showing!');
+ * 	}
+ *
+ * 	(at)RequiresUserPermissions('BAN_MEMBERS') // This subcommand requires the user of the command to be able to ban members.
+ * 	public async add(message: Message) {
+ * 		return message.channel.send('Adding!');
+ * 	}
+ *
+ * 	(at)RequiresUserPermissions('BAN_MEMBERS') // This subcommand requires the user of the command to be able to ban members.
+ * 	public async remove(message: Message) {
+ * 		return message.channel.send('Removing!');
+ * 	}
+ *
+ * 	(at)RequiresUserPermissions('BAN_MEMBERS') // This subcommand requires the user of the command to be able to ban members.
+ * 	public async reset(message: Message) {
+ * 		return message.channel.send('Resetting!');
+ * 	}
+ * }
+ * ```
+ */
+export const RequiresUserPermissions = (...permissionsResolvable: PermissionResolvable[]): MethodDecorator => {
+	const resolved = new Permissions(permissionsResolvable);
+	const resolvedIncludesServerPermissions = Boolean(resolved.bitfield & DMAvailableUserPermissions.bitfield);
+
+	return createFunctionPrecondition((message: Message) => {
+		if (resolvedIncludesServerPermissions && isDMChannel(message.channel)) {
+			throw new UserError({
+				identifier: DecoratorIdentifiers.RequiresUserPermissionsGuildOnly,
+				message: 'Sorry but that command can only be used in a server because you do not have sufficient permissions in DMs'
+			});
+		}
+
+		if (isGuildBasedChannel(message.channel)) {
+			const missingPermissions = message.channel.permissionsFor(message.member!).missing(resolved);
+
+			if (missingPermissions.length) {
+				throw new UserError({
+					identifier: DecoratorIdentifiers.RequiresUserPermissionsMissingPermissions,
+					message: `Sorry, but you are not allowed to do that. You are missing the permissions: ${missingPermissions}`,
 					context: {
 						missing: missingPermissions
 					}

--- a/packages/decorators/src/piece-decorators.ts
+++ b/packages/decorators/src/piece-decorators.ts
@@ -20,7 +20,7 @@ import { createClassDecorator, createProxy } from './utils';
  * 		const msg = await message.channel.send('Ping?');
  *
  * 		return msg.edit(
- * 			`Pong! Bot Latency ${Math.round(this.context.client.ws.ping)}ms. API Latency ${msg.createdTimestamp - message.createdTimestamp}ms.`
+ * 			`Pong! Client Latency ${Math.round(this.context.client.ws.ping)}ms. API Latency ${msg.createdTimestamp - message.createdTimestamp}ms.`
  * 		);
  * 	}
  * }

--- a/packages/decorators/tests/djs/RequiresClientPermissions.test.ts
+++ b/packages/decorators/tests/djs/RequiresClientPermissions.test.ts
@@ -1,7 +1,7 @@
 import { UserError } from '@sapphire/framework';
-import { PermissionResolvable, Permissions, PermissionString, Message as DJSMessage } from 'discord.js';
+import { Message as DJSMessage, PermissionResolvable, Permissions, PermissionString } from 'discord.js';
 import diff from 'lodash/difference';
-import { DecoratorIdentifiers, RequiresPermissions } from '../../src';
+import { DecoratorIdentifiers, RequiresClientPermissions } from '../../src';
 
 interface BitField {
 	missing(resolvedPermissions: Permissions): PermissionString[];
@@ -33,10 +33,10 @@ function buildMessage(channelType: DJSMessage['channel']['type'], ...givenPermis
 	};
 }
 
-describe('RequiresPermissions', () => {
+describe('RequiresClientPermissions', () => {
 	describe('WITH DM-compatible permissions', () => {
 		class Test {
-			@RequiresPermissions(['SEND_MESSAGES', 'ATTACH_FILES'])
+			@RequiresClientPermissions(['SEND_MESSAGES', 'ATTACH_FILES'])
 			public getValue(_message: Message) {
 				return Promise.resolve('Resolved');
 			}
@@ -56,7 +56,8 @@ describe('RequiresPermissions', () => {
 
 				await expect(result).rejects.toThrowError(
 					new UserError({
-						identifier: DecoratorIdentifiers.RequiresPermissionsMissingPermissions,
+						identifier: DecoratorIdentifiers.RequiresClientPermissionsMissingPermissions,
+						message: `Sorry, but I am not allowed to do that. I am missing the permissions: ATTACH_FILES`,
 						context: {
 							missing: ['ATTACH_FILES']
 						}
@@ -69,7 +70,8 @@ describe('RequiresPermissions', () => {
 
 				await expect(result).rejects.toThrowError(
 					new UserError({
-						identifier: DecoratorIdentifiers.RequiresPermissionsMissingPermissions,
+						identifier: DecoratorIdentifiers.RequiresClientPermissionsMissingPermissions,
+						message: `Sorry, but I am not allowed to do that. I am missing the permissions: SEND_MESSAGES,ATTACH_FILES`,
 						context: {
 							missing: ['SEND_MESSAGES', 'ATTACH_FILES']
 						}
@@ -89,7 +91,7 @@ describe('RequiresPermissions', () => {
 
 	describe('WITH DM-incompatible permissions', () => {
 		class Test {
-			@RequiresPermissions(['MANAGE_MESSAGES', 'ADD_REACTIONS', 'EMBED_LINKS'])
+			@RequiresClientPermissions(['MANAGE_MESSAGES', 'ADD_REACTIONS', 'EMBED_LINKS'])
 			public getValue(_message: Message) {
 				return Promise.resolve('Resolved');
 			}
@@ -103,7 +105,8 @@ describe('RequiresPermissions', () => {
 
 				await expect(result).rejects.toThrowError(
 					new UserError({
-						identifier: DecoratorIdentifiers.RequiresPermissionsGuildOnly
+						identifier: DecoratorIdentifiers.RequiresClientPermissionsGuildOnly,
+						message: 'Sorry but that command can only be used in a server because I do not have sufficient permissions in DMs'
 					})
 				);
 			});

--- a/packages/decorators/tests/djs/RequiresUserPermissions.test.ts
+++ b/packages/decorators/tests/djs/RequiresUserPermissions.test.ts
@@ -1,0 +1,115 @@
+import { UserError } from '@sapphire/framework';
+import { Message as DJSMessage, PermissionResolvable, Permissions, PermissionString } from 'discord.js';
+import diff from 'lodash/difference';
+import { DecoratorIdentifiers, RequiresUserPermissions } from '../../src';
+
+interface BitField {
+	missing(resolvedPermissions: Permissions): PermissionString[];
+}
+
+interface Message {
+	channel: {
+		type: DJSMessage['channel']['type'];
+		permissionsFor(): BitField;
+	};
+	guild: {
+		me: any;
+	};
+}
+
+function buildMissing(resolvedPermissions: Permissions, ...givenPermissions: PermissionResolvable[]) {
+	return diff(resolvedPermissions.toArray(), new Permissions(givenPermissions).toArray());
+}
+
+function buildMessage(channelType: DJSMessage['channel']['type'], ...givenPermissions: PermissionResolvable[]): Message {
+	return {
+		channel: {
+			type: channelType,
+			permissionsFor: () => ({ missing: (resolvedPermissions: Permissions) => buildMissing(resolvedPermissions, givenPermissions) })
+		},
+		guild: {
+			me: ''
+		}
+	};
+}
+
+describe('RequiresUserPermissions', () => {
+	describe('WITH DM-compatible permissions', () => {
+		class Test {
+			@RequiresUserPermissions(['SEND_MESSAGES', 'ATTACH_FILES'])
+			public getValue(_message: Message) {
+				return Promise.resolve('Resolved');
+			}
+		}
+
+		const instance = new Test();
+
+		describe('WITH channel === GUILD_TEXT', () => {
+			test('GIVEN has permission THEN returns resolved', async () => {
+				const result = await instance.getValue(buildMessage('GUILD_TEXT', 'SEND_MESSAGES', 'ATTACH_FILES'));
+
+				expect(result).toBe('Resolved');
+			});
+
+			test('GIVEN lacking 1 permission THEN throws UserError', async () => {
+				const result = instance.getValue(buildMessage('GUILD_TEXT', 'SEND_MESSAGES'));
+
+				await expect(result).rejects.toThrowError(
+					new UserError({
+						identifier: DecoratorIdentifiers.RequiresUserPermissionsMissingPermissions,
+						message: 'Sorry, but you are not allowed to do that. You are missing the permissions: ATTACH_FILES',
+						context: {
+							missing: ['ATTACH_FILES']
+						}
+					})
+				);
+			});
+
+			test('GIVEN lacking 2 permissions THEN throws UserError', async () => {
+				const result = instance.getValue(buildMessage('GUILD_TEXT'));
+
+				await expect(result).rejects.toThrowError(
+					new UserError({
+						identifier: DecoratorIdentifiers.RequiresUserPermissionsMissingPermissions,
+						message: 'Sorry, but you are not allowed to do that. You are missing the permissions: SEND_MESSAGES,ATTACH_FILES',
+						context: {
+							missing: ['SEND_MESSAGES', 'ATTACH_FILES']
+						}
+					})
+				);
+			});
+		});
+
+		describe('WITH channel === DM', () => {
+			test('GIVEN no additional permissions THEN resolves', async () => {
+				const result = await instance.getValue(buildMessage('DM'));
+
+				expect(result).toBe('Resolved');
+			});
+		});
+	});
+
+	describe('WITH DM-incompatible permissions', () => {
+		class Test {
+			@RequiresUserPermissions(['MANAGE_MESSAGES', 'ADD_REACTIONS', 'EMBED_LINKS'])
+			public getValue(_message: Message) {
+				return Promise.resolve('Resolved');
+			}
+		}
+
+		const instance = new Test();
+
+		describe('WITH channel === DM', () => {
+			test('GIVEN no additional permissions THEN resolves', async () => {
+				const result = instance.getValue(buildMessage('DM'));
+
+				await expect(result).rejects.toThrowError(
+					new UserError({
+						identifier: DecoratorIdentifiers.RequiresUserPermissionsGuildOnly,
+						message: 'Sorry but that command can only be used in a server because you do not have sufficient permissions in DMs'
+					})
+				);
+			});
+		});
+	});
+});

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -523,7 +523,7 @@ export class PaginatedMessage {
 	 * Executes the {@link PaginatedMessage} and sends the pages corresponding with {@link PaginatedMessage.index}.
 	 * The handler will start collecting reactions and running actions once all actions have been reacted to the message.
 	 * @param message The message that triggered this {@link PaginatedMessage}.
-	 * Generally this will be the command message, but it can also be another message from your bot, i.e. to indicate a loading state.
+	 * Generally this will be the command message, but it can also be another message from your client, i.e. to indicate a loading state.
 	 * @param target The user who will be able to interact with the reactions of this {@link PaginatedMessage}. Defaults to `message.author`.
 	 */
 	public async run(message: Message, target = message.author): Promise<this> {


### PR DESCRIPTION
- feat(decorators): add default messages to errors thrown by `RequiresPermissions`
- feat(decorators): add `RequiresUserPermissions`

BREAKING CHANGE: `RequiresPermissions` has been renamed to `RequiresBotPermissions`
BREAKING CHANGE: enum entry `DecoratorIdentifiers.RequiresPermissionsGuildOnly` has been changed to `DecoratorIdentifiers.RequiresBotPermissionsGuildOnly`
BREAKING CHANGE: enum entry `DecoratorIdentifiers.RequiresPermissionsMissingPermissions` has been changed to `DecoratorIdentifiers.RequiresBotPermissionsMissingPermissions`
BREAKING CHANGE: i18n identifier `requiresPermissionsGuildOnly` has been changed to `requiresBotPermissionsGuildOnly`
BREAKING CHANGE: i18n identifier `requiresPermissionsMissingPermissions` has been changed to `requiresBotPermissionsMissingPermissions`