### PR TITLE
feat(fetch): migrate to using cross-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@rollup/plugin-commonjs": "^20.0.0",
 		"@rollup/plugin-node-resolve": "^13.0.4",
 		"@sapphire/framework": "^1.0.2",
-		"@sapphire/plugin-api": "^2.2.0",
 		"@types/fs-extra": "^9.0.12",
 		"@types/jest": "^26.0.24",
 		"@types/lodash": "^4.14.172",

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -20,18 +20,17 @@
     -   [Description](#description)
     -   [Features](#features)
     -   [Installation](#installation)
-        -   [Node-fetch types](#node-fetch-types)
     -   [Usage](#usage)
-        -   [`GET`-ing JSON data](#get-ing-json-data)
-        -   [`GET`-ing Buffer data (images, etc.)](#get-ing-buffer-data-images-etc)
-        -   [`POST`-ing JSON data](#post-ing-json-data)
+        -   [`GET`ting JSON data](#getting-json-data)
+        -   [`GET`ting Buffer data (images, etc.)](#getting-buffer-data-images-etc)
+        -   [`POST`ing JSON data](#posting-json-data)
     -   [API Documentation](#api-documentation)
     -   [Buy us some doughnuts](#buy-us-some-doughnuts)
     -   [Contributors ✨](#contributors-%E2%9C%A8)
 
 ## Description
 
-[node-fetch] is already a great library for making API calls, but because it focuses solely on bringing the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to Node.js, it doesn't provide specific error messages and handling for different return types (JSON, Buffer, plain text, etc). This is where `@sapphire/fetch` comes in. The syntax is more restrictive than that of [node-fetch], but that makes it consistent and easier to use in TypeScript.
+[cross-fetch] is already a great library for making API calls, but because it focuses solely on bringing the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to Node.js, it doesn't provide specific error messages and handling for different return types (JSON, Buffer, plain text, etc). This is where `@sapphire/fetch` comes in. The syntax is more restrictive than that of [cross-fetch], but that makes it consistent and easier to use in TypeScript.
 
 ## Features
 
@@ -40,6 +39,7 @@
 -   Exported `const enum` for the common return data types.
 -   Throws distinctive errors when the API returns a "not ok" status code to make them easier to understand.
 -   Enforces casting the return type when requesting JSON data, to ensure your return data is strictly typed.
+-   Uses [cross-fetch] so this package can be used in NodeJS (where it uses [node-fetch]) and browser (where it uses [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API))
 
 ## Installation
 
@@ -48,16 +48,6 @@ You can use the following command to install this package, or replace `npm insta
 ```sh
 npm install @sapphire/fetch
 ```
-
-### Node-fetch types
-
-TypeScript users should also add `@types/node-fetch`:
-
-```sh
-npm install --save-dev @types/node-fetch
-```
-
-Alternatively, you can enable the [`skipLibChecks`](https://www.typescriptlang.org/tsconfig/#skipLibCheck) TypeScript compiler option
 
 ## Usage
 
@@ -187,3 +177,4 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 <!-- LINKS -->
 
 [node-fetch]: https://github.com/node-fetch/node-fetch
+[cross-fetch]: https://github.com/lquixada/cross-fetch

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -6,6 +6,8 @@
 	"license": "MIT",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
+	"browser": "dist/index.umd.js",
+	"unpkg": "dist/index.umd.js",
 	"types": "dist/index.d.ts",
 	"exports": {
 		"import": "./dist/index.mjs",
@@ -16,14 +18,12 @@
 	"scripts": {
 		"test": "jest",
 		"lint": "eslint src tests --ext ts --fix -c ../../.eslintrc",
-		"build": "tsc -b src",
-		"postbuild": "gen-esm-wrapper dist/index.js dist/index.mjs",
+		"build": "rollup -c",
 		"start": "yarn build -w",
 		"prepublishOnly": "yarn build"
 	},
 	"dependencies": {
-		"node-fetch": "^2.6.1",
-		"tslib": "2.x"
+		"cross-fetch": "^3.1.4"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/fetch/rollup.config.js
+++ b/packages/fetch/rollup.config.js
@@ -1,0 +1,11 @@
+import baseConfig from '../../scripts/rollup.config';
+
+export default baseConfig({
+	umdName: 'SapphireFetch',
+	umdGlobals: {
+		'cross-fetch': 'fetch'
+	},
+	extraOptions: {
+		external: ['cross-fetch']
+	}
+});

--- a/packages/fetch/rollup.config.js
+++ b/packages/fetch/rollup.config.js
@@ -3,7 +3,7 @@ import baseConfig from '../../scripts/rollup.config';
 export default baseConfig({
 	umdName: 'SapphireFetch',
 	umdGlobals: {
-		'cross-fetch': 'fetch'
+		'cross-fetch': 'window'
 	},
 	extraOptions: {
 		external: ['cross-fetch']

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -1,4 +1,3 @@
 export * from './lib/fetch';
-export { fetch as default } from './lib/fetch';
 export * from './lib/QueryError';
 export * from './lib/types';

--- a/packages/fetch/src/lib/QueryError.ts
+++ b/packages/fetch/src/lib/QueryError.ts
@@ -1,6 +1,3 @@
-import type { Response } from 'node-fetch';
-import type { URL } from 'url';
-
 /**
  * The QueryError class which is thrown by the `fetch` method
  */
@@ -16,9 +13,9 @@ export class QueryError extends Error {
 	// eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
 	#json: unknown;
 
-	public constructor(url: string | URL, code: number, response: Response, body: string) {
+	public constructor(url: string, code: number, response: Response, body: string) {
 		super(`Failed to request '${url}' with code ${code}.`);
-		this.url = typeof url === 'string' ? url : url.href;
+		this.url = url;
 		this.code = code;
 		this.body = body;
 		this.response = response;

--- a/packages/fetch/src/lib/QueryError.ts
+++ b/packages/fetch/src/lib/QueryError.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
 /**
  * The QueryError class which is thrown by the `fetch` method
  */

--- a/packages/fetch/src/lib/fetch.ts
+++ b/packages/fetch/src/lib/fetch.ts
@@ -40,7 +40,7 @@ export async function fetch(url: URL | string, options?: RequestInit | FetchResu
 		type = FetchResultTypes.JSON;
 	}
 
-	// Transform the URL to a String if an URL object was passed
+	// Transform the URL to a String, in case an URL object was passed
 	const stringUrl = String(url);
 
 	const result: Response = await nodeFetch(stringUrl, options);

--- a/packages/fetch/src/lib/fetch.ts
+++ b/packages/fetch/src/lib/fetch.ts
@@ -1,4 +1,4 @@
-import nodeFetch from 'cross-fetch';
+import { fetch as nodeFetch } from 'cross-fetch';
 import { QueryError } from './QueryError';
 import { FetchResultTypes } from './types';
 

--- a/packages/fetch/src/lib/fetch.ts
+++ b/packages/fetch/src/lib/fetch.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
 import { fetch as nodeFetch } from 'cross-fetch';
 import { QueryError } from './QueryError';
 import { FetchResultTypes } from './types';

--- a/packages/fetch/src/lib/fetch.ts
+++ b/packages/fetch/src/lib/fetch.ts
@@ -1,5 +1,4 @@
-import nodeFetch, { RequestInit, Response } from 'node-fetch';
-import type { URL } from 'url';
+import nodeFetch from 'cross-fetch';
 import { QueryError } from './QueryError';
 import { FetchResultTypes } from './types';
 
@@ -7,23 +6,26 @@ import { FetchResultTypes } from './types';
  * Performs an HTTP(S) fetch
  * @param url The URL to send the request to. Can be either a `string` or an `URL` object.
  * `url` should be an absolute url, such as `https://example.com/`. A path-relative URL (`/file/under/root`) or protocol-relative URL (`//can-be-http-or-https.com/`) will result in a rejected `Promise`.
- * @param optionsOrType Either the [node-fetch options](https://github.com/node-fetch/node-fetch#options) or one of the {@link FetchResultTypes}
- * @param type Only needs to be provided if the second parameter are [node-fetch options](https://github.com/node-fetch/node-fetch#options). One of the {@link FetchResultTypes} that will determine how the result is returned.
+ * @param optionsOrType Either the [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) ({@link RequestInit} for TypeScript) or one of the {@link FetchResultTypes}
+ * @param type Only needs to be provided if the second parameter are [Request options](https://developer.mozilla.org/en-US/docs/Web/API/Request) ({@link RequestInit} for TypeScript). One of the {@link FetchResultTypes} that will determine how the result is returned.
  * @returns The return type is determined by the provided `type`.
  * - When using `FetchResultTypes.JSON` then the return type is `unknown` by default. The type should be specified by filling in the generic type of the function, or casting the result.
- * - When using `FetchResultTypes.Buffer` the return type is always [`Buffer`](https://nodejs.org/api/buffer.html)
- * - When using `FetchResultTypes.Text` the return type is always `string`
- * - When using `FetchResultTypes.Result` the return type is always [`Response`](https://github.com/node-fetch/node-fetch#class-response)
+ * - When using `FetchResultTypes.Buffer` the return type will be [`Buffer`](https://nodejs.org/api/buffer.html).
+ * - When using `FetchResultTypes.Blob` the return type will be a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+ * - When using `FetchResultTypes.Text` the return type will be a `string`
+ * - When using `FetchResultTypes.Result` the return type will be a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) ({@link Response} in typescript)
  */
 export async function fetch<R>(url: URL | string, type?: FetchResultTypes.JSON): Promise<R>;
 export async function fetch<R>(url: URL | string, options: RequestInit, type?: FetchResultTypes.JSON): Promise<R>;
 export async function fetch(url: URL | string, type: FetchResultTypes.Buffer): Promise<Buffer>;
 export async function fetch(url: URL | string, options: RequestInit, type: FetchResultTypes.Buffer): Promise<Buffer>;
+export async function fetch(url: URL | string, type: FetchResultTypes.Blob): Promise<Blob>;
+export async function fetch(url: URL | string, options: RequestInit, type: FetchResultTypes.Blob): Promise<Blob>;
 export async function fetch(url: URL | string, type: FetchResultTypes.Text): Promise<string>;
 export async function fetch(url: URL | string, options: RequestInit, type: FetchResultTypes.Text): Promise<string>;
 export async function fetch(url: URL | string, type: FetchResultTypes.Result): Promise<Response>;
 export async function fetch(url: URL | string, options: RequestInit, type: FetchResultTypes.Result): Promise<Response>;
-export async function fetch<R>(url: URL | string, options: RequestInit, type: FetchResultTypes): Promise<Response | Buffer | string | R>;
+export async function fetch<R>(url: URL | string, options: RequestInit, type: FetchResultTypes): Promise<Response | Blob | Buffer | string | R>;
 export async function fetch(url: URL | string, options?: RequestInit | FetchResultTypes, type?: FetchResultTypes) {
 	if (typeof options === 'undefined') {
 		options = {};
@@ -35,14 +37,19 @@ export async function fetch(url: URL | string, options?: RequestInit | FetchResu
 		type = FetchResultTypes.JSON;
 	}
 
-	const result: Response = await nodeFetch(url, options);
-	if (!result.ok) throw new QueryError(url, result.status, result, await result.clone().text());
+	// Transform the URL to a String if an URL object was passed
+	const stringUrl = String(url);
+
+	const result: Response = await nodeFetch(stringUrl, options);
+	if (!result.ok) throw new QueryError(stringUrl, result.status, result, await result.clone().text());
 
 	switch (type) {
 		case FetchResultTypes.Result:
 			return result;
 		case FetchResultTypes.Buffer:
-			return result.buffer();
+			return Buffer.from(await (await result.blob()).arrayBuffer());
+		case FetchResultTypes.Blob:
+			return result.blob();
 		case FetchResultTypes.JSON:
 			return result.json();
 		case FetchResultTypes.Text:

--- a/packages/fetch/src/lib/types.ts
+++ b/packages/fetch/src/lib/types.ts
@@ -12,6 +12,7 @@ export const enum FetchResultTypes {
 	/**
 	 * Returns only the body, as a [Buffer](https://nodejs.org/api/buffer.html).
 	 * @remark Does not work in a Browser environment. For browsers use {@link FetchResultTypes.Blob} instead.
+	 * If you use this type in a Browsers environment a {@link ReferenceError `ReferenceError: Buffer is not defined`} will be thrown!
 	 */
 	Buffer = 'buffer',
 	/**

--- a/packages/fetch/src/lib/types.ts
+++ b/packages/fetch/src/lib/types.ts
@@ -10,9 +10,15 @@ export const enum FetchResultTypes {
 	 */
 	JSON = 'json',
 	/**
-	 * Returns only the body, as a [Buffer](https://nodejs.org/api/buffer.html). Similar to [`Body.blob()`](https://developer.mozilla.org/en-US/docs/Web/API/Body/blob).
+	 * Returns only the body, as a [Buffer](https://nodejs.org/api/buffer.html).
+	 * @remark Does not work in a Browser environment. For browsers use {@link FetchResultTypes.Blob} instead.
 	 */
 	Buffer = 'buffer',
+	/**
+	 * Returns only the body, as a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+	 * @remark For NodeJS environment other `FetchResultTypes` are recommended, but you can use a Blob if you want to.
+	 */
+	Blob = 'blob',
 	/**
 	 * Returns only the body, as plain text. Similar to [`Body.text()`](https://developer.mozilla.org/en-US/docs/Web/API/Body/text).
 	 */

--- a/packages/fetch/tsconfig.json
+++ b/packages/fetch/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"extends": "../ts-config/src/tsconfig.json",
 	"compilerOptions": {
+		"module": "ESNext",
 		"outDir": "build",
-		"rootDir": "src",
-		"composite": true,
-		"tsBuildInfoFile": "./dist/.tsbuildinfo"
+		"rootDir": "src"
 	},
 	"include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,18 +1680,6 @@
     "@discordjs/collection" "^0.1.6"
     tslib "^2.2.0"
 
-"@sapphire/plugin-api@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sapphire/plugin-api/-/plugin-api-2.2.0.tgz#2c9be0f7110d034ccf39f32271b9153cd7b19369"
-  integrity sha512-HXFnN7LY39OyiSUmkXMVeGVGFw7AD8MnGdFGmY1u0Rcr9aCbIisgivgy1VsWJbsoeplGz9rjonquHwGhcTOivw==
-  dependencies:
-    "@types/node-fetch" "^2.5.10"
-    "@types/psl" "^1.1.0"
-    "@types/ws" latest
-    node-fetch "^2.6.1"
-    psl "^1.8.0"
-    tslib "^2.3.0"
-
 "@sapphire/ratelimits@^1.2.1":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@sapphire/ratelimits/-/ratelimits-1.2.5.tgz#61e8e72c7ec37c67b958fcb324c892673dc68197"
@@ -1858,7 +1846,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node-fetch@^2.5.10", "@types/node-fetch@^2.5.12":
+"@types/node-fetch@^2.5.12":
   version "2.5.12"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
   integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
@@ -1886,11 +1874,6 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
   integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
-"@types/psl@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/psl/-/psl-1.1.0.tgz#390c5df1613b166ce3c3eb9fda4d93dc3eeec7b5"
-  integrity sha512-HhZnoLAvI2koev3czVPzBNRYvdrzJGLjQbWZhqFmS9Q6a0yumc5qtfSahBGb5g+6qWvA8iiQktqGkwoIXa/BNQ==
-
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -1908,7 +1891,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/ws@^7.4.7", "@types/ws@latest":
+"@types/ws@^7.4.7":
   version "7.4.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
   integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
@@ -2947,6 +2930,13 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-fetch@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -6015,7 +6005,7 @@ nock@^13.1.1:
     lodash.set "^4.3.2"
     propagate "^2.0.0"
 
-node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -6772,7 +6762,7 @@ protocols@^1.1.0, protocols@^1.4.0:
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
   integrity sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==
 
-psl@^1.1.28, psl@^1.8.0:
+psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==


### PR DESCRIPTION
All in all pretty poggers that it can be used in browsers after this

**_Once this is merged then I'll release all utilities packages which includes those for DJS v13._**

BREAKING CHANGE: `fetch` is no longer on the default export. Use a named import instead.
BREAKING CHANGE: This package no longer depends on `node-fetch`
BREAKING CHANGE: This package no longer depends on `@types/node-fetch` for TypeScript users
