### PR TITLE
fix: message prompter types

### DIFF
--- a/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
@@ -1,6 +1,6 @@
 import type { Ctor } from '@sapphire/utilities';
-import type { CollectorFilter, DMChannel, EmojiResolvable, Message, MessageReaction, NewsChannel, TextChannel, User } from 'discord.js';
-import { MessagePrompterMessage, MessagePrompterStrategies } from './constants';
+import type { CollectorFilter, EmojiResolvable, Message, MessageReaction, User } from 'discord.js';
+import { MessagePrompterChannelTypes, MessagePrompterMessage, MessagePrompterStrategies } from './constants';
 import type {
 	IMessagePrompterExplicitConfirmReturn,
 	IMessagePrompterExplicitMessageReturn,
@@ -134,7 +134,7 @@ export class MessagePrompter<S extends MessagePrompterStrategies = MessagePrompt
 	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/#/docs/main/stable/typedef/CollectorFilter CollectorFilter} predicate callback.
 	 */
 	public run<Filter extends S extends keyof StrategyFilters ? StrategyFilters[S] : unknown[]>(
-		channel: TextChannel | NewsChannel | DMChannel,
+		channel: MessagePrompterChannelTypes,
 		authorOrFilter: User | CollectorFilter<Filter>
 	): S extends keyof StrategyReturns ? Promise<StrategyReturns[S]> : never {
 		return this.strategy.run(channel, authorOrFilter as User | CollectorFilter<unknown[]>) as S extends keyof StrategyReturns

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/constants.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/constants.ts
@@ -1,5 +1,6 @@
 import type { ArgumentTypes } from '@sapphire/utilities';
-import type { PartialTextBasedChannelFields } from 'discord.js';
+import type { CategoryChannel, PartialTextBasedChannelFields, StoreChannel } from 'discord.js';
+import type { ChannelTypes, VoiceBasedChannelTypes } from '../utility-types';
 
 /**
  * A type to extend multiple discord types and simplify usage in {@link MessagePrompter}
@@ -12,3 +13,5 @@ export const enum MessagePrompterStrategies {
 	Message = 'message',
 	Reaction = 'reaction'
 }
+
+export type MessagePrompterChannelTypes = Exclude<ChannelTypes, VoiceBasedChannelTypes | StoreChannel | CategoryChannel>;

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/index.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/index.ts
@@ -1,4 +1,4 @@
-export { MessagePrompterMessage, MessagePrompterStrategies } from './constants';
+export { MessagePrompterChannelTypes, MessagePrompterMessage, MessagePrompterStrategies } from './constants';
 export * from './ExplicitReturnTypes';
 export * from './MessagePrompter';
 export * from './strategies/MessagePrompterBaseStrategy';

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterConfirmStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterConfirmStrategy.ts
@@ -1,5 +1,5 @@
-import type { CollectorFilter, DMChannel, EmojiResolvable, MessageReaction, NewsChannel, TextChannel, User } from 'discord.js';
-import type { MessagePrompterMessage } from '../constants';
+import type { CollectorFilter, EmojiResolvable, MessageReaction, User } from 'discord.js';
+import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
 import type { IMessagePrompterExplicitConfirmReturn } from '../ExplicitReturnTypes';
 import type { IMessagePrompterConfirmStrategyOptions } from '../strategyOptions';
 import { MessagePrompterBaseStrategy } from './MessagePrompterBaseStrategy';
@@ -35,7 +35,7 @@ export class MessagePrompterConfirmStrategy extends MessagePrompterBaseStrategy 
 	 * @returns A promise that resolves to a boolean denoting the value of the input (`true` for yes, `false` for no).
 	 */
 	public override async run(
-		channel: TextChannel | NewsChannel | DMChannel,
+		channel: MessagePrompterChannelTypes,
 		authorOrFilter: User | CollectorFilter<[MessageReaction, User]>
 	): Promise<IMessagePrompterExplicitConfirmReturn | boolean> {
 		const response = await this.collectReactions(channel, authorOrFilter, [this.confirmEmoji, this.cancelEmoji]);

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterNumberStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterNumberStrategy.ts
@@ -1,5 +1,5 @@
-import type { CollectorFilter, DMChannel, EmojiIdentifierResolvable, MessageReaction, NewsChannel, TextChannel, User } from 'discord.js';
-import type { MessagePrompterMessage } from '../constants';
+import type { CollectorFilter, EmojiIdentifierResolvable, MessageReaction, User } from 'discord.js';
+import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
 import type { IMessagePrompterExplicitNumberReturn } from '../ExplicitReturnTypes';
 import type { IMessagePrompterNumberStrategyOptions } from '../strategyOptions';
 import { MessagePrompterBaseStrategy } from './MessagePrompterBaseStrategy';
@@ -39,7 +39,7 @@ export class MessagePrompterNumberStrategy extends MessagePrompterBaseStrategy i
 	 * @returns A promise that resolves to the selected number within the range.
 	 */
 	public async run(
-		channel: TextChannel | NewsChannel | DMChannel,
+		channel: MessagePrompterChannelTypes,
 		authorOrFilter: User | CollectorFilter<[MessageReaction, User]>
 	): Promise<IMessagePrompterExplicitNumberReturn | number> {
 		// 0 and 10 are the maximum available emojis as a number

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterReactionStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterReactionStrategy.ts
@@ -1,14 +1,5 @@
-import type {
-	CollectorFilter,
-	DMChannel,
-	EmojiIdentifierResolvable,
-	EmojiResolvable,
-	MessageReaction,
-	NewsChannel,
-	TextChannel,
-	User
-} from 'discord.js';
-import type { MessagePrompterMessage } from '../constants';
+import type { CollectorFilter, EmojiIdentifierResolvable, EmojiResolvable, MessageReaction, User } from 'discord.js';
+import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
 import type { IMessagePrompterExplicitReturnBase } from '../ExplicitReturnTypes';
 import type { IMessagePrompterReactionStrategyOptions } from '../strategyOptions';
 import { MessagePrompterBaseStrategy } from './MessagePrompterBaseStrategy';
@@ -38,7 +29,7 @@ export class MessagePrompterReactionStrategy extends MessagePrompterBaseStrategy
 	 * @returns A promise that resolves to the reaction object.
 	 */
 	public async run(
-		channel: TextChannel | NewsChannel | DMChannel,
+		channel: MessagePrompterChannelTypes,
 		authorOrFilter: User | CollectorFilter<[MessageReaction, User]>
 	): Promise<IMessagePrompterExplicitReturnBase | string | EmojiResolvable> {
 		if (!this.reactions?.length) throw new TypeError('There are no reactions provided.');

--- a/packages/discord.js-utilities/src/lib/type-guards.ts
+++ b/packages/discord.js-utilities/src/lib/type-guards.ts
@@ -11,7 +11,7 @@ import type {
 	ThreadChannel,
 	VoiceChannel
 } from 'discord.js';
-import type { ChannelTypes, GuildTextBasedChannelTypes, NonThreadGuildTextBasedChannelTypes } from './utility-types';
+import type { ChannelTypes, GuildTextBasedChannelTypes, NonThreadGuildTextBasedChannelTypes, TextBasedChannelTypes } from './utility-types';
 import { Nullish, isNullish } from '@sapphire/utilities';
 
 /**
@@ -127,6 +127,16 @@ export function isPublicThreadChannel(channel: ChannelTypes | Nullish): channel 
  */
 export function isPrivateThreadChannel(channel: ChannelTypes | Nullish): channel is ThreadChannel {
 	return channel?.type === 'GUILD_PRIVATE_THREAD';
+}
+
+/**
+ * Checks whether a given channel is a {@link TextBasedChannelTypes}. This means it has a `send` method.
+ * @param channel The channel to check.
+ */
+export function isTextBasedChannel(channel: ChannelTypes | Nullish): channel is TextBasedChannelTypes {
+	if (isNullish(channel)) return false;
+
+	return !isNullish((channel as TextBasedChannelTypes).send);
 }
 
 /**


### PR DESCRIPTION
- feat(discord.js-utilities): add `isTextBasedChannel` channel type guard
- fix(discord.js-utilities): allow more channel types for MessagePrompter
