### PR TITLE
fix(discord.js-utilities): remove `MessagePrompterStrategies` in favour of `keyof StrategyReturns`

### DIFF
--- a/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
@@ -1,6 +1,6 @@
 import type { Ctor } from '@sapphire/utilities';
 import type { CollectorFilter, EmojiResolvable, Message, MessageReaction, User } from 'discord.js';
-import { MessagePrompterChannelTypes, MessagePrompterMessage, MessagePrompterStrategies } from './constants';
+import type { MessagePrompterChannelTypes, MessagePrompterMessage } from './constants';
 import type {
 	IMessagePrompterExplicitConfirmReturn,
 	IMessagePrompterExplicitMessageReturn,
@@ -20,23 +20,24 @@ import type {
 } from './strategyOptions';
 
 export interface StrategyReturns {
-	[MessagePrompterStrategies.Confirm]: IMessagePrompterExplicitConfirmReturn | boolean;
-	[MessagePrompterStrategies.Message]: IMessagePrompterExplicitMessageReturn | Message;
-	[MessagePrompterStrategies.Number]: IMessagePrompterExplicitNumberReturn | number;
-	[MessagePrompterStrategies.Reaction]: IMessagePrompterExplicitReturnBase | string | EmojiResolvable;
+	confirm: IMessagePrompterExplicitConfirmReturn | boolean;
+	number: IMessagePrompterExplicitMessageReturn | Message;
+	message: IMessagePrompterExplicitNumberReturn | number;
+	reaction: IMessagePrompterExplicitReturnBase | string | EmojiResolvable;
 }
+
 export interface StrategyOptions {
-	[MessagePrompterStrategies.Confirm]: IMessagePrompterConfirmStrategyOptions;
-	[MessagePrompterStrategies.Message]: IMessagePrompterStrategyOptions;
-	[MessagePrompterStrategies.Number]: IMessagePrompterNumberStrategyOptions;
-	[MessagePrompterStrategies.Reaction]: IMessagePrompterReactionStrategyOptions;
+	confirm: IMessagePrompterConfirmStrategyOptions;
+	number: IMessagePrompterStrategyOptions;
+	message: IMessagePrompterNumberStrategyOptions;
+	reaction: IMessagePrompterReactionStrategyOptions;
 }
 
 export interface StrategyFilters {
-	[MessagePrompterStrategies.Confirm]: [MessageReaction, User];
-	[MessagePrompterStrategies.Message]: [Message];
-	[MessagePrompterStrategies.Number]: [MessageReaction, User];
-	[MessagePrompterStrategies.Reaction]: [MessageReaction, User];
+	confirm: [MessageReaction, User];
+	number: [Message];
+	message: [MessageReaction, User];
+	reaction: [MessageReaction, User];
 }
 
 /**
@@ -94,7 +95,7 @@ export interface StrategyFilters {
  * const result = await handler.run(channel, author);
  * ```
  */
-export class MessagePrompter<S extends MessagePrompterStrategies = MessagePrompterStrategies.Confirm> {
+export class MessagePrompter<S extends keyof StrategyReturns = 'confirm'> {
 	/**
 	 * The strategy used in {@link MessagePrompter.run}
 	 */
@@ -146,7 +147,7 @@ export class MessagePrompter<S extends MessagePrompterStrategies = MessagePrompt
 	 * The available strategies
 	 */
 	public static strategies: Map<
-		MessagePrompterStrategies,
+		keyof StrategyReturns,
 		Ctor<
 			| ConstructorParameters<typeof MessagePrompterConfirmStrategy>
 			| ConstructorParameters<typeof MessagePrompterNumberStrategy>
@@ -156,14 +157,14 @@ export class MessagePrompter<S extends MessagePrompterStrategies = MessagePrompt
 		>
 		// @ts-expect-error 2322
 	> = new Map([
-		[MessagePrompterStrategies.Confirm, MessagePrompterConfirmStrategy],
-		[MessagePrompterStrategies.Number, MessagePrompterNumberStrategy],
-		[MessagePrompterStrategies.Reaction, MessagePrompterReactionStrategy],
-		[MessagePrompterStrategies.Message, MessagePrompterMessageStrategy]
+		['confirm', MessagePrompterConfirmStrategy],
+		['number', MessagePrompterNumberStrategy],
+		['message', MessagePrompterReactionStrategy],
+		['reaction', MessagePrompterMessageStrategy]
 	]);
 
 	/**
 	 * The default strategy to use
 	 */
-	public static defaultStrategy: MessagePrompterStrategies = MessagePrompterStrategies.Confirm;
+	public static defaultStrategy: keyof StrategyReturns = 'confirm';
 }

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/constants.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/constants.ts
@@ -7,11 +7,4 @@ import type { ChannelTypes, VoiceBasedChannelTypes } from '../utility-types';
  */
 export type MessagePrompterMessage = ArgumentTypes<PartialTextBasedChannelFields['send']>[0];
 
-export const enum MessagePrompterStrategies {
-	Confirm = 'confirm',
-	Number = 'number',
-	Message = 'message',
-	Reaction = 'reaction'
-}
-
 export type MessagePrompterChannelTypes = Exclude<ChannelTypes, VoiceBasedChannelTypes | StoreChannel | CategoryChannel>;

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/index.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/index.ts
@@ -1,4 +1,4 @@
-export { MessagePrompterChannelTypes, MessagePrompterMessage, MessagePrompterStrategies } from './constants';
+export { MessagePrompterChannelTypes, MessagePrompterMessage } from './constants';
 export * from './ExplicitReturnTypes';
 export * from './MessagePrompter';
 export * from './strategies/MessagePrompterBaseStrategy';


### PR DESCRIPTION
fix(discord.js-utilities): remove `MessagePrompterStrategies` in favour of `keyof StrategyReturns`

BREAKING CHANGE: `MessagePrompterStrategies` does no exist as it was not mutable with type augmentation
BREAKING CHANGE: If you had custom strategies then be sure to instead module augment `StrategyReturns` with your added keys.