### PR TITLE
feat(discord.js-utilities): option to make Prompters edit a message

### DIFF
--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
@@ -43,9 +43,9 @@ export abstract class MessagePrompterBaseStrategy {
 	 */
 	public constructor(type: string, message: MessagePrompterMessage, options?: IMessagePrompterStrategyOptions) {
 		this.type = type;
-		this.timeout = options?.timeout ?? MessagePrompterBaseStrategy.defaultStrategyOptions.timeout;
-		this.explicitReturn = options?.explicitReturn ?? MessagePrompterBaseStrategy.defaultStrategyOptions.explicitReturn;
-		this.editMessage = options?.editMessage;
+		this.timeout = options?.timeout ?? MessagePrompterBaseStrategy.defaultStrategyOptions.timeout ?? 10 * 1000;
+		this.explicitReturn = options?.explicitReturn ?? MessagePrompterBaseStrategy.defaultStrategyOptions.explicitReturn ?? false;
+		this.editMessage = options?.editMessage ?? MessagePrompterBaseStrategy.defaultStrategyOptions.editMessage ?? undefined;
 		this.message = message;
 	}
 
@@ -127,6 +127,7 @@ export abstract class MessagePrompterBaseStrategy {
 	 */
 	public static defaultStrategyOptions: IMessagePrompterStrategyOptions = {
 		timeout: 10 * 1000,
-		explicitReturn: false
+		explicitReturn: false,
+		editMessage: undefined
 	};
 }

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
@@ -57,7 +57,7 @@ export abstract class MessagePrompterBaseStrategy {
 		reactions: string[] | EmojiIdentifierResolvable[]
 	): Promise<IMessagePrompterExplicitReturnBase> {
 		if (isTextBasedChannel(channel)) {
-			if (typeof this.editMessage !== 'undefined' && this.editMessage.editable) {
+			if (!isNullish(this.editMessage) && this.editMessage.editable) {
 				this.appliedMessage = await this.editMessage.edit(this.message);
 			} else {
 				this.appliedMessage = await channel.send(this.message);

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
@@ -1,4 +1,4 @@
-import type { Awaited } from '@sapphire/utilities';
+import { Awaited, isNullish } from '@sapphire/utilities';
 import type { CollectorFilter, CollectorOptions, EmojiIdentifierResolvable, Message, MessageReaction, User } from 'discord.js';
 import { isTextBasedChannel } from '../../type-guards';
 import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
@@ -125,7 +125,7 @@ export abstract class MessagePrompterBaseStrategy {
 	/**
 	 * The default strategy options
 	 */
-	public static defaultStrategyOptions: Required<IMessagePrompterStrategyOptions> = {
+	public static defaultStrategyOptions: IMessagePrompterStrategyOptions = {
 		timeout: 10 * 1000,
 		explicitReturn: false
 	};

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
@@ -27,7 +27,11 @@ export class MessagePrompterMessageStrategy extends MessagePrompterBaseStrategy 
 		authorOrFilter: User | CollectorFilter<[Message]>
 	): Promise<IMessagePrompterExplicitMessageReturn | Message> {
 		if (isTextBasedChannel(channel)) {
-			this.appliedMessage = await channel.send(this.message);
+			if (typeof this.editMessage !== 'undefined' && this.editMessage.editable) {
+				this.appliedMessage = await this.editMessage.edit(this.message);
+			} else {
+				this.appliedMessage = await channel.send(this.message);
+			}
 
 			const collector = await channel.awaitMessages({
 				...this.createMessagePromptFilter(authorOrFilter),

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
@@ -1,5 +1,5 @@
+import { isNullish } from '@sapphire/utilities';
 import type { CollectorFilter, CollectorOptions, Message, User } from 'discord.js';
-import { isNullish } from '../../../../../utilities/dist';
 import { isTextBasedChannel } from '../../type-guards';
 import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
 import type { IMessagePrompterExplicitMessageReturn } from '../ExplicitReturnTypes';

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
@@ -1,4 +1,5 @@
 import type { CollectorFilter, CollectorOptions, Message, User } from 'discord.js';
+import { isNullish } from '../../../../../utilities/dist';
 import { isTextBasedChannel } from '../../type-guards';
 import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
 import type { IMessagePrompterExplicitMessageReturn } from '../ExplicitReturnTypes';

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
@@ -27,7 +27,7 @@ export class MessagePrompterMessageStrategy extends MessagePrompterBaseStrategy 
 		authorOrFilter: User | CollectorFilter<[Message]>
 	): Promise<IMessagePrompterExplicitMessageReturn | Message> {
 		if (isTextBasedChannel(channel)) {
-			if (typeof this.editMessage !== 'undefined' && this.editMessage.editable) {
+			if (!isNullish(this.editMessage) && this.editMessage.editable) {
 				this.appliedMessage = await this.editMessage.edit(this.message);
 			} else {
 				this.appliedMessage = await channel.send(this.message);

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategyOptions.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategyOptions.ts
@@ -1,8 +1,9 @@
-import type { EmojiIdentifierResolvable } from 'discord.js';
+import type { EmojiIdentifierResolvable, Message } from 'discord.js';
 
 export interface IMessagePrompterStrategyOptions {
 	timeout?: number;
 	explicitReturn?: boolean;
+	editMessage?: Message;
 }
 
 export interface IMessagePrompterConfirmStrategyOptions extends IMessagePrompterStrategyOptions {


### PR DESCRIPTION
You can now give the `editMessage` option to any strategy, and if it is set & the message is editable, then the bot will edit it rather than send a new one.

*Please pack it so I can test it further*