### PR TITLE
fix(discord.js-utilities): account thread channels in permission checks

### DIFF
--- a/packages/discord.js-utilities/src/lib/type-guards.ts
+++ b/packages/discord.js-utilities/src/lib/type-guards.ts
@@ -26,7 +26,7 @@ export function isCategoryChannel(channel: ChannelTypes | Nullish): channel is C
  * Checks whether a given channel is a {@link DMChannel}
  * @param channel The channel to check
  */
-export function isDMChannel(channel: ChannelTypes | Nullish): channel is DMChannel {
+export function isDMChannel(channel: ChannelTypes | Nullish): channel is DMChannel | PartialDMChannel {
 	return channel?.type === 'DM';
 }
 

--- a/packages/discord.js-utilities/src/lib/utilities.ts
+++ b/packages/discord.js-utilities/src/lib/utilities.ts
@@ -1,5 +1,6 @@
 import { isNullish, Nullish } from '@sapphire/utilities';
 import { Permissions } from 'discord.js';
+import { isThreadChannel } from '..';
 import { isDMChannel, isGuildBasedChannel } from './type-guards';
 import type { ChannelTypes } from './utility-types';
 
@@ -27,6 +28,7 @@ const canSendMessagesPermissions = new Permissions([canReadMessagesPermissions, 
 export function canSendMessages(channel: ChannelTypes | Nullish): boolean {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
+	if (isThreadChannel(channel) && !channel.sendable) return false;
 
 	return canDoUtility(channel, canSendMessagesPermissions);
 }
@@ -41,6 +43,7 @@ const canSendEmbedsPermissions = new Permissions([canSendMessagesPermissions, 'E
 export function canSendEmbeds(channel: ChannelTypes | Nullish): boolean {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
+	if (isThreadChannel(channel) && !channel.sendable) return false;
 
 	return canDoUtility(channel, canSendEmbedsPermissions);
 }
@@ -55,6 +58,7 @@ const canSendAttachmentsPermissions = new Permissions([canSendMessagesPermission
 export function canSendAttachments(channel: ChannelTypes | Nullish): boolean {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
+	if (isThreadChannel(channel) && !channel.sendable) return false;
 
 	return canDoUtility(channel, canSendAttachmentsPermissions);
 }
@@ -69,6 +73,7 @@ const canReactPermissions = new Permissions([canSendMessagesPermissions, 'READ_M
 export function canReact(channel: ChannelTypes | Nullish) {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
+	if (isThreadChannel(channel) && channel.archived) return false;
 
 	return canDoUtility(channel, canReactPermissions);
 }

--- a/packages/discord.js-utilities/src/lib/utilities.ts
+++ b/packages/discord.js-utilities/src/lib/utilities.ts
@@ -1,6 +1,5 @@
 import { isNullish, Nullish } from '@sapphire/utilities';
 import { Permissions } from 'discord.js';
-import { isThreadChannel } from '..';
 import { isDMChannel, isGuildBasedChannel } from './type-guards';
 import type { ChannelTypes } from './utility-types';
 
@@ -28,7 +27,7 @@ const canSendMessagesPermissions = new Permissions([canReadMessagesPermissions, 
 export function canSendMessages(channel: ChannelTypes | Nullish): boolean {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
-	if (isThreadChannel(channel) && !channel.sendable) return false;
+	if (channel.isThread() && !channel.sendable) return false;
 
 	return canDoUtility(channel, canSendMessagesPermissions);
 }
@@ -43,7 +42,7 @@ const canSendEmbedsPermissions = new Permissions([canSendMessagesPermissions, 'E
 export function canSendEmbeds(channel: ChannelTypes | Nullish): boolean {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
-	if (isThreadChannel(channel) && !channel.sendable) return false;
+	if (channel.isThread() && !channel.sendable) return false;
 
 	return canDoUtility(channel, canSendEmbedsPermissions);
 }
@@ -58,7 +57,7 @@ const canSendAttachmentsPermissions = new Permissions([canSendMessagesPermission
 export function canSendAttachments(channel: ChannelTypes | Nullish): boolean {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
-	if (isThreadChannel(channel) && !channel.sendable) return false;
+	if (channel.isThread() && !channel.sendable) return false;
 
 	return canDoUtility(channel, canSendAttachmentsPermissions);
 }
@@ -73,7 +72,7 @@ const canReactPermissions = new Permissions([canSendMessagesPermissions, 'READ_M
 export function canReact(channel: ChannelTypes | Nullish) {
 	if (isNullish(channel)) return false;
 	if (isDMChannel(channel)) return true;
-	if (isThreadChannel(channel) && channel.archived) return false;
+	if (channel.isThread() && channel.archived) return false;
 
 	return canDoUtility(channel, canReactPermissions);
 }


### PR DESCRIPTION
Although I'm not 100% sure if this logic is correct, cc: @vladfrangu
