### PR TITLE
fix(utilities): rename `Awaited<T>` to `Awaitable<T>`

### DIFF
--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterBaseStrategy.ts
@@ -1,4 +1,4 @@
-import { Awaited, isNullish } from '@sapphire/utilities';
+import { Awaitable, isNullish } from '@sapphire/utilities';
 import type { CollectorFilter, CollectorOptions, EmojiIdentifierResolvable, Message, MessageReaction, User } from 'discord.js';
 import { isTextBasedChannel } from '../../type-guards';
 import type { MessagePrompterChannelTypes, MessagePrompterMessage } from '../constants';
@@ -49,7 +49,7 @@ export abstract class MessagePrompterBaseStrategy {
 		this.message = message;
 	}
 
-	public abstract run(channel: MessagePrompterChannelTypes, authorOrFilter: User | CollectorFilter<unknown[]>): Awaited<unknown>;
+	public abstract run(channel: MessagePrompterChannelTypes, authorOrFilter: User | CollectorFilter<unknown[]>): Awaitable<unknown>;
 
 	protected async collectReactions(
 		channel: MessagePrompterChannelTypes,

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1,5 +1,5 @@
 import { Time } from '@sapphire/time-utilities';
-import { Awaited, isFunction } from '@sapphire/utilities';
+import { Awaitable, isFunction } from '@sapphire/utilities';
 import type { RESTPostAPIChannelMessageJSONBody } from 'discord-api-types/v9';
 import {
 	Collection,
@@ -962,7 +962,7 @@ export interface PaginatedMessage {
  */
 export interface IPaginatedMessageAction {
 	id: string;
-	run(context: PaginatedMessageActionContext): Awaited<unknown>;
+	run(context: PaginatedMessageActionContext): Awaitable<unknown>;
 }
 
 /**
@@ -1016,7 +1016,7 @@ export interface PaginatedMessageOptions {
  * on the provided pages and we can only guarantee this will work properly when using the utility methods.
  */
 export type MessagePage =
-	| ((index: number, pages: MessagePage[], handler: PaginatedMessage) => Awaited<MessagePayload | MessageOptions>)
+	| ((index: number, pages: MessagePage[], handler: PaginatedMessage) => Awaitable<MessagePayload | MessageOptions>)
 	| MessagePayload
 	| MessageOptions;
 

--- a/packages/utilities/src/lib/utilityTypes.ts
+++ b/packages/utilities/src/lib/utilityTypes.ts
@@ -66,7 +66,7 @@ export type SecondArgument<T> = T extends (arg1: unknown, arg2: infer U, ...args
 /**
  * ReturnType for a function that can return either a value or a `Promise` with that value
  */
-export type Awaited<T> = PromiseLike<T> | T;
+export type Awaitable<T> = PromiseLike<T> | T;
 
 /**
  * Type union for the full 2 billion dollar mistake in the JavaScript ecosystem

--- a/typedoc.json
+++ b/typedoc.json
@@ -19,7 +19,7 @@
 		"PrettierSchema",
 		"InternalAsyncQueueDeferredPromise",
 		"Ctor",
-		"Awaited",
+		"Awaitable",
 		"Nullish",
 		"EmbedData",
 		"EmbedInformation",


### PR DESCRIPTION
With https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/, we'll eventually run into a name conflict between the built-in `Awaited<T>` type, and our type.

This PR fixes the conflict by renaming our type to `Awaitable<T>`
