### PR TITLE
build: remove unsupported yarn flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"docs": "typedoc",
 		"commit": "git-cz",
 		"cz": "git-cz",
-		"update": "yarn upgrade-interactive --latest",
+		"update": "yarn upgrade-interactive",
 		"prepare": "husky install .github/husky"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Yarn v3 no longer has the `--latest` flag. [docs](https://yarnpkg.com/cli/upgrade-interactive)