### PR TITLE
fix(eslint-config): allow type and regular imports

### DIFF
--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -194,7 +194,7 @@ export const eslintConfig = {
 		'no-dupe-class-members': 'off',
 		'no-dupe-keys': 'error',
 		'no-duplicate-case': 'error',
-		'no-duplicate-imports':'off',
+		'no-duplicate-imports': 'off',
 		'no-else-return': 'warn',
 		'no-empty': 'off',
 		'no-empty-character-class': 'error',

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -86,6 +86,12 @@ export const eslintConfig = {
 		],
 		'@typescript-eslint/no-base-to-string': 'error',
 		'@typescript-eslint/no-dupe-class-members': 'error',
+		'@typescript-eslint/no-duplicate-imports': [
+			'error',
+			{
+				includeExports: false
+			}
+		],
 		'@typescript-eslint/no-empty-interface': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
 		'@typescript-eslint/no-extra-non-null-assertion': 'error',
@@ -188,12 +194,7 @@ export const eslintConfig = {
 		'no-dupe-class-members': 'off',
 		'no-dupe-keys': 'error',
 		'no-duplicate-case': 'error',
-		'no-duplicate-imports': [
-			'error',
-			{
-				includeExports: false
-			}
-		],
+		'no-duplicate-imports':'off',
 		'no-else-return': 'warn',
 		'no-empty': 'off',
 		'no-empty-character-class': 'error',

--- a/packages/eslint-config/tests/__snapshots__/eslint.test.ts.snap
+++ b/packages/eslint-config/tests/__snapshots__/eslint.test.ts.snap
@@ -85,6 +85,12 @@ Object {
     ],
     "@typescript-eslint/no-base-to-string": "error",
     "@typescript-eslint/no-dupe-class-members": "error",
+    "@typescript-eslint/no-duplicate-imports": Array [
+      "error",
+      Object {
+        "includeExports": false,
+      },
+    ],
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-extra-non-null-assertion": "error",
@@ -199,12 +205,7 @@ Object {
     "no-dupe-class-members": "off",
     "no-dupe-keys": "error",
     "no-duplicate-case": "error",
-    "no-duplicate-imports": Array [
-      "error",
-      Object {
-        "includeExports": false,
-      },
-    ],
+    "no-duplicate-imports": "off",
     "no-else-return": "warn",
     "no-empty": "off",
     "no-empty-character-class": "error",


### PR DESCRIPTION
Use [`@typescript-eslint/no-duplicate-imports`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-duplicate-imports.md) instead of `no-duplicate-imports`.

> This rule extends the base `eslint/no-duplicate-imports` rule. This version adds support for type-only import and export.