### PR TITLE
feat(discord-utilities): add discord limits

### DIFF
--- a/packages/discord-utilities/src/index.ts
+++ b/packages/discord-utilities/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/regexes';
+export * from './lib/limits';

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -14,7 +14,7 @@ export const ChannelLimits = {
 	 * Maximum viewers allowed per screen share.
 	 */
 	MaximumViewersPerScreenShare: 250
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord embeds.
@@ -59,7 +59,7 @@ export const EmbedLimits = {
 	 * Maximum characters allowed in an embed, in total.
 	 */
 	MaximumTotalCharacters: 6000
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord emojis.
@@ -69,7 +69,7 @@ export const EmojiLimits = {
 	 * Maximum characters allowed in a custom guild emoji.
 	 */
 	MaximumEmojiNameLength: 32
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord guilds.
@@ -83,7 +83,7 @@ export const GuildLimits = {
 	 * Maximum roles allowed in a guild.
 	 */
 	MaximumRoles: 250
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord guild members.
@@ -93,7 +93,7 @@ export const GuildMemberLimits = {
 	 * Maximum characters allowed in the display name of a guild member.
 	 */
 	MaximumDisplayNameLength: 32
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord messages.
@@ -113,7 +113,7 @@ export const MessageLimits = {
 	 * Maximum characters allowed in a single message for a nitro user.
 	 */
 	MaximumNitroLength: 4000
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord roles.
@@ -123,7 +123,7 @@ export const RoleLimits = {
 	 * Maximum characters allowed in a role name.
 	 */
 	MaximumNameLength: 100
-};
+} as const;
 
 /**
  * Namespace containing limits related to Discord users and Direct Messages.
@@ -133,4 +133,4 @@ export const UserLimits = {
 	 * Maximum viewers allowed per screen share.
 	 */
 	MaximumUsersPerDMGroup: 10
-};
+} as const;

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -130,7 +130,7 @@ export const RoleLimits = {
  */
 export const UserLimits = {
 	/**
-	 * Maximum viewers allowed per screen share.
+	 * Maximum numbers of users in a DM group.
 	 */
 	MaximumUsersPerDMGroup: 10
 } as const;

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -1,99 +1,112 @@
-/**
- * Maximum characters allowed in a channel description.
- */
-export const MaxChannelDescriptionLength = 1024;
+export const ChannelLimits = {
+	/**
+	 * Maximum characters allowed in a channel description.
+	 */
+	MaximumDescriptionLength: 1024,
+	/**
+	 * Maximum characters allowed in a channel name.
+	 */
+	MaximumNameLength: 100,
+	/**
+	 * Maximum viewers allowed per screen share.
+	 */
+	MaximumViewersPerScreenShare: 250
+};
 
-/**
- * Maximum characters allowed in a channel name.
- */
-export const MaxChannelNameLength = 100;
+export const EmbedLimits = {
+	/**
+	 * Maximum characters allowed in the author field of an embed.
+	 */
+	MaximumAuthorNameLength: 256,
 
-/**
- * Maximum channels allowed per guild, including category channels.
- */
-export const MaxChannelsPerGuild = 500;
+	/**
+	 * Maximum characters allowed in an embed description.
+	 */
+	MaximumDescriptionLength: 4096,
 
-/**
- * Maximum characters allowed in the display name of a guild member.
- */
-export const MaxDisplayNameLength = 32;
+	/**
+	 * Maximum characters allowed in the name of a field in an embed.
+	 */
+	MaximumFieldNameLength: 256,
 
-/**
- * Maximum characters allowed in the author field of an embed.
- */
-export const MaxEmbedAuthorNameLength = 256;
+	/**
+	 * Maximum fields allowed in an embed.
+	 */
+	MaximumFields: 25,
 
-/**
- * Maximum characters allowed in an embed description.
- */
-export const MaxEmbedDescriptionLength = 4096;
+	/**
+	 * Maximum characters allowed in the avlue of a field in an embed.
+	 */
+	MaximumFieldValueLength: 1024,
 
-/**
- * Maximum characters allowed in the name of a field in an embed.
- */
-export const MaxEmbedFieldNameLength = 256;
+	/**
+	 * Maximum characters allowed in a footer of an embed.
+	 */
+	MaximumFooterLength: 2048,
 
-/**
- * Maximum fields allowed in an embed.
- */
-export const MaxEmbedFields = 25;
+	/**
+	 * Maximum characters allowed in the title of an embed.
+	 */
+	MaximumTitleLength: 256,
 
-/**
- * Maximum characters allowed in the avlue of a field in an embed.
- */
-export const MaxEmbedFieldValueLength = 1024;
+	/**
+	 * Maximum characters allowed in an embed, in total.
+	 */
+	MaximumTotalCharacters: 6000
+};
 
-/**
- * Maximum characters allowed in a footer of an embed.
- */
-export const MaxEmbedFooterLength = 2048;
+export const EmojiLimits = {
+	/**
+	 * Maximum characters allowed in a custom guild emoji.
+	 */
+	MaximumEmojiNameLength: 32
+};
 
-/**
- * Maximum embeds allowed in a single message.
- */
-export const MaxEmbedsPerMessage = 10;
+export const GuildLimits = {
+	/**
+	 * Maximum channels allowed per guild, including category channels.
+	 */
+	MaximumChannels: 500,
+	/**
+	 * Maximum roles allowed in a guild.
+	 */
+	MaximumRoles: 250
+};
 
-/**
- * Maximum characters allowed in the title of an embed.
- */
-export const MaxEmbedTitleLength = 256;
+export const GuildMemberLimits = {
+	/**
+	 * Maximum characters allowed in the display name of a guild member.
+	 */
+	MaxDisplayNameLength: 32
+};
 
-/**
- * Maximum characters allowed in an embed, in total.
- */
-export const MaxEmbedTotalCharacters = 6000;
+export const MessageLimits = {
+	/**
+	 * Maximum embeds allowed in a single message.
+	 */
+	MaximumEmbeds: 10,
 
-/**
- * Maximum characters allowed in a custom guild emoji.
- */
-export const MaxEmojiNameLength = 32;
+	/**
+	 * Maximum characters allowed in a single message for a user.
+	 */
+	MaximumLength: 2000,
 
-/**
- * Maximum characters allowed in a single message for a user.
- */
-export const MaxMessageLength = 2000;
+	/**
+	 * Maximum characters allowed in a single message for a nitro user.
+	 */
+	MaximumNitroLength: 4000
+};
 
-/**
- * Maximum characters allowed in a single message for a nitro user.
- */
-export const MaxNitroMessageLength = 4000;
+export const RoleLimits = {
+	/**
+	 * Maximum characters allowed in a role name.
+	 */
+	MaximumNameLength: 100
+};
 
-/**
- * Maximum characters allowed in a role name.
- */
-export const MaxRoleNameLength = 100;
-
-/**
- * Maximum roles allowed in a guild.
- */
-export const MaxRolesPerGuild = 250;
-
-/**
- * Maximum viewers allowed per screen share.
- */
-export const MaxUsersPerDMGroup = 10;
-
-/**
- * Maximum viewers allowed per screen share.
- */
-export const MaxViewersPerScreenShare = 250;
+export const UserLimits = {
+	/**
+	 * Maximum viewers allowed per screen share.
+	 */
+	MaximumUsersPerDMGroup: 10
+};

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -77,7 +77,7 @@ export const GuildMemberLimits = {
 	/**
 	 * Maximum characters allowed in the display name of a guild member.
 	 */
-	MaxDisplayNameLength: 32
+	MaximumDisplayNameLength: 32
 };
 
 export const MessageLimits = {

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -1,3 +1,6 @@
+/**
+ * Namespace containing limits related to Discord channels.
+ */
 export const ChannelLimits = {
 	/**
 	 * Maximum characters allowed in a channel description.
@@ -13,6 +16,9 @@ export const ChannelLimits = {
 	MaximumViewersPerScreenShare: 250
 };
 
+/**
+ * Namespace containing limits related to Discord embeds.
+ */
 export const EmbedLimits = {
 	/**
 	 * Maximum characters allowed in the author field of an embed.
@@ -55,6 +61,9 @@ export const EmbedLimits = {
 	MaximumTotalCharacters: 6000
 };
 
+/**
+ * Namespace containing limits related to Discord emojis.
+ */
 export const EmojiLimits = {
 	/**
 	 * Maximum characters allowed in a custom guild emoji.
@@ -62,6 +71,9 @@ export const EmojiLimits = {
 	MaximumEmojiNameLength: 32
 };
 
+/**
+ * Namespace containing limits related to Discord guilds.
+ */
 export const GuildLimits = {
 	/**
 	 * Maximum channels allowed per guild, including category channels.
@@ -73,6 +85,9 @@ export const GuildLimits = {
 	MaximumRoles: 250
 };
 
+/**
+ * Namespace containing limits related to Discord guild members.
+ */
 export const GuildMemberLimits = {
 	/**
 	 * Maximum characters allowed in the display name of a guild member.
@@ -80,6 +95,9 @@ export const GuildMemberLimits = {
 	MaximumDisplayNameLength: 32
 };
 
+/**
+ * Namespace containing limits related to Discord messages.
+ */
 export const MessageLimits = {
 	/**
 	 * Maximum embeds allowed in a single message.
@@ -97,6 +115,9 @@ export const MessageLimits = {
 	MaximumNitroLength: 4000
 };
 
+/**
+ * Namespace containing limits related to Discord roles.
+ */
 export const RoleLimits = {
 	/**
 	 * Maximum characters allowed in a role name.
@@ -104,6 +125,9 @@ export const RoleLimits = {
 	MaximumNameLength: 100
 };
 
+/**
+ * Namespace containing limits related to Discord users and Direct Messages.
+ */
 export const UserLimits = {
 	/**
 	 * Maximum viewers allowed per screen share.

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -13,7 +13,7 @@ export const ChannelLimits = {
 	/**
 	 * Maximum viewers allowed per screen share.
 	 */
-	MaximumViewersPerScreenShare: 250
+	MaximumViewersPerScreenShare: 50
 } as const;
 
 /**

--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -1,0 +1,99 @@
+/**
+ * Maximum characters allowed in a channel description.
+ */
+export const MaxChannelDescriptionLength = 1024;
+
+/**
+ * Maximum characters allowed in a channel name.
+ */
+export const MaxChannelNameLength = 100;
+
+/**
+ * Maximum channels allowed per guild, including category channels.
+ */
+export const MaxChannelsPerGuild = 500;
+
+/**
+ * Maximum characters allowed in the display name of a guild member.
+ */
+export const MaxDisplayNameLength = 32;
+
+/**
+ * Maximum characters allowed in the author field of an embed.
+ */
+export const MaxEmbedAuthorNameLength = 256;
+
+/**
+ * Maximum characters allowed in an embed description.
+ */
+export const MaxEmbedDescriptionLength = 4096;
+
+/**
+ * Maximum characters allowed in the name of a field in an embed.
+ */
+export const MaxEmbedFieldNameLength = 256;
+
+/**
+ * Maximum fields allowed in an embed.
+ */
+export const MaxEmbedFields = 25;
+
+/**
+ * Maximum characters allowed in the avlue of a field in an embed.
+ */
+export const MaxEmbedFieldValueLength = 1024;
+
+/**
+ * Maximum characters allowed in a footer of an embed.
+ */
+export const MaxEmbedFooterLength = 2048;
+
+/**
+ * Maximum embeds allowed in a single message.
+ */
+export const MaxEmbedsPerMessage = 10;
+
+/**
+ * Maximum characters allowed in the title of an embed.
+ */
+export const MaxEmbedTitleLength = 256;
+
+/**
+ * Maximum characters allowed in an embed, in total.
+ */
+export const MaxEmbedTotalCharacters = 6000;
+
+/**
+ * Maximum characters allowed in a custom guild emoji.
+ */
+export const MaxEmojiNameLength = 32;
+
+/**
+ * Maximum characters allowed in a single message for a user.
+ */
+export const MaxMessageLength = 2000;
+
+/**
+ * Maximum characters allowed in a single message for a nitro user.
+ */
+export const MaxNitroMessageLength = 4000;
+
+/**
+ * Maximum characters allowed in a role name.
+ */
+export const MaxRoleNameLength = 100;
+
+/**
+ * Maximum roles allowed in a guild.
+ */
+export const MaxRolesPerGuild = 250;
+
+/**
+ * Maximum viewers allowed per screen share.
+ */
+export const MaxUsersPerDMGroup = 10;
+
+/**
+ * Maximum viewers allowed per screen share.
+ */
+export const MaxViewersPerScreenShare = 250;


### PR DESCRIPTION
Add different limits related to discord.

I have intentionnally missed a few ones such as the one bellow, because i wanted your opinion:
- max # of persons in a channel with a video [25]
- max # of guilds for a classic / nitro user (why would a bot need that?) [100 / 200 i think]
- ~~max # of members in a guild (if you reach max you can ask discord for more so this isn't a hard limit) [500k]~~ available in discord.js
- other limits that can be 💥 with boosts, such as max # of emojis/stickers per guild and max upload size [50 / 0 / 8Mo, 100 / 15 / 8Mo, 150 / 30 / 50Mo, 250 / 60 / 100Mo]
