### PR TITLE
feat(DurationFormatter): added separators for joining units

### DIFF
--- a/packages/time-utilities/src/lib/DurationFormatter.ts
+++ b/packages/time-utilities/src/lib/DurationFormatter.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_UNITS, TimeTypes } from './constants';
+import { DEFAULT_SEPARATORS, DEFAULT_UNITS, TimeTypes } from './constants';
 
 /**
  * The duration of each time type in milliseconds
@@ -22,7 +22,7 @@ const kTimeDurations: readonly [TimeTypes, number][] = [
 export class DurationFormatter {
 	public constructor(public units: DurationFormatAssetsTime = DEFAULT_UNITS) {}
 
-	public format(duration: number, precision = 7) {
+	public format(duration: number, precision = 7, separators: DurationFormatSeparators = DEFAULT_SEPARATORS) {
 		const output: string[] = [];
 		const negative = duration < 0;
 		if (negative) duration *= -1;
@@ -33,13 +33,13 @@ export class DurationFormatter {
 
 			const floored = Math.floor(substraction);
 			duration -= floored * timeDuration;
-			output.push(addUnit(floored, this.units[type]));
+			output.push(addUnit(floored, this.units[type], separators.left));
 
 			// If the output has enough precision, break
 			if (output.length >= precision) break;
 		}
 
-		return `${negative ? '-' : ''}${output.join(' ') || addUnit(0, this.units.second)}`;
+		return `${negative ? '-' : ''}${output.join(separators.right) || addUnit(0, this.units.second, separators.left)}`;
 	}
 }
 
@@ -48,9 +48,14 @@ export class DurationFormatter {
  * @param time The duration of said unit
  * @param unit The unit language assets
  */
-function addUnit(time: number, unit: DurationFormatAssetsUnit) {
-	if (Reflect.has(unit, time)) return `${time} ${Reflect.get(unit, time)}`;
-	return `${time} ${unit.DEFAULT}`;
+function addUnit(time: number, unit: DurationFormatAssetsUnit, separator: string) {
+	if (Reflect.has(unit, time)) return `${time}${separator}${Reflect.get(unit, time)}`;
+	return `${time}${separator}${unit.DEFAULT}`;
+}
+
+export interface DurationFormatSeparators {
+	left: string;
+	right: string;
 }
 
 export interface DurationFormatAssetsUnit extends Record<number, string> {

--- a/packages/time-utilities/src/lib/DurationFormatter.ts
+++ b/packages/time-utilities/src/lib/DurationFormatter.ts
@@ -22,7 +22,14 @@ const kTimeDurations: readonly [TimeTypes, number][] = [
 export class DurationFormatter {
 	public constructor(public units: DurationFormatAssetsTime = DEFAULT_UNITS) {}
 
-	public format(duration: number, precision = 7, separators: DurationFormatSeparators = DEFAULT_SEPARATORS) {
+	public format(
+		duration: number,
+		precision = 7,
+		{
+			left: leftSeparator = DEFAULT_SEPARATORS.left,
+			right: rightSeparator = DEFAULT_SEPARATORS.right
+		}: DurationFormatSeparators = DEFAULT_SEPARATORS
+	) {
 		const output: string[] = [];
 		const negative = duration < 0;
 		if (negative) duration *= -1;
@@ -33,13 +40,13 @@ export class DurationFormatter {
 
 			const floored = Math.floor(substraction);
 			duration -= floored * timeDuration;
-			output.push(addUnit(floored, this.units[type], separators.left));
+			output.push(addUnit(floored, this.units[type], leftSeparator!));
 
 			// If the output has enough precision, break
 			if (output.length >= precision) break;
 		}
 
-		return `${negative ? '-' : ''}${output.join(separators.right) || addUnit(0, this.units.second, separators.left)}`;
+		return `${negative ? '-' : ''}${output.join(rightSeparator) || addUnit(0, this.units.second, leftSeparator!)}`;
 	}
 }
 
@@ -54,8 +61,8 @@ function addUnit(time: number, unit: DurationFormatAssetsUnit, separator: string
 }
 
 export interface DurationFormatSeparators {
-	left: string;
-	right: string;
+	left?: string;
+	right?: string;
 }
 
 export interface DurationFormatAssetsUnit extends Record<number, string> {

--- a/packages/time-utilities/src/lib/constants.ts
+++ b/packages/time-utilities/src/lib/constants.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { DurationFormatAssetsTime } from './DurationFormatter';
+import type { DurationFormatAssetsTime, DurationFormatSeparators } from './DurationFormatter';
 
 /**
  * The supported time types
@@ -124,4 +124,9 @@ export const DEFAULT_UNITS: DurationFormatAssetsTime = {
 		1: 'second',
 		DEFAULT: 'seconds'
 	}
+};
+
+export const DEFAULT_SEPARATORS: DurationFormatSeparators = {
+	left: ' ',
+	right: ' '
 };


### PR DESCRIPTION
You can specify a left and right separator that is inserted as so `<left>UNIT<right>` when calling `.format()`

Example:
```typescript
const default_units = new DurationFormatter();
const custom_units = new DurationFormatter({
  second: { DEFAULT: "s" },
  minute: { DEFAULT: "m" },
  hour: { DEFAULT: "h" },
  day: { DEFAULT: "d" },
  week: { DEFAULT: "w" },
  month: { DEFAULT: "m" },
  year: { DEFAULT: "y" },
});

console.log(default_units.format(120_000_000, 7));
// 1 day 9 hours 20 minutes
console.log(default_units.format(120_000_000, 7, { left: " ", right: ", " }));
// 1 day, 9 hours, 20 minutes
console.log(custom_units.format(120_000_000, 7, { left: "", right: " " }));
// 1d 9h 20m
```
The left and right separators default to a space.