### PR TITLE
feat(Snowflake): rework entire package

### DIFF
--- a/packages/snowflake/src/lib/DiscordSnowflake.ts
+++ b/packages/snowflake/src/lib/DiscordSnowflake.ts
@@ -1,58 +1,8 @@
-import { DeconstructedSnowflake, Snowflake, SnowflakeGenerateOptions } from './Snowflake';
+import { Snowflake } from './Snowflake';
 
 /**
  * A class for parsing snowflake ids using Discord's snowflake epoch
  *
  * Which is 2015-01-01 at 00:00:00.000 UTC+0, {@linkplain https://discord.com/developers/docs/reference#snowflakes}
  */
-export class DiscordSnowflake extends Snowflake {
-	public constructor() {
-		super(DiscordSnowflake.Epoch);
-	}
-
-	/**
-	 * Discord epoch (`2015-01-01T00:00:00.000Z`)
-	 * @see {@linkplain https://discord.com/developers/docs/reference#snowflakes}
-	 */
-	public static readonly Epoch = 1420070400000n;
-
-	/**
-	 * Deconstructs a snowflake given a snowflake ID
-	 * @param id the snowflake to deconstruct
-	 * @returns a deconstructed snowflake
-	 * @example
-	 * ```typescript
-	 * const snowflake = DiscordSnowflake.decode('3971046231244935168');
-	 * ```
-	 */
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	public static decode = DiscordSnowflake.deconstruct;
-
-	/**
-	 * Deconstructs a snowflake given a snowflake ID
-	 * @param id the snowflake to deconstruct
-	 * @returns a deconstructed snowflake
-	 * @example
-	 * ```typescript
-	 * const snowflake = DiscordSnowflake.deconstruct('3971046231244935168');
-	 * ```
-	 */
-	public static deconstruct(id: string | bigint): DeconstructedSnowflake {
-		return new DiscordSnowflake().deconstruct(id);
-	}
-
-	/**
-	 * Generates a snowflake given an epoch and optionally a timestamp
-	 * @param options {@link SnowflakeGenerateOptions} to pass into the generator
-	 *
-	 * **note** when increment is not provided it defaults to `0n`
-	 * @example
-	 * ```typescript
-	 * const snowflake = DiscordSnowflake.generate();
-	 * ```
-	 * @returns A unique snowflake
-	 */
-	public static generate(options: SnowflakeGenerateOptions = { timestamp: Date.now() }) {
-		return new DiscordSnowflake().generate(options);
-	}
-}
+export const DiscordSnowflake = new Snowflake(1420070400000n);

--- a/packages/snowflake/src/lib/TwitterSnowflake.ts
+++ b/packages/snowflake/src/lib/TwitterSnowflake.ts
@@ -1,58 +1,8 @@
-import { DeconstructedSnowflake, Snowflake, SnowflakeGenerateOptions } from './Snowflake';
+import { Snowflake } from './Snowflake';
 
 /**
  * A class for parsing snowflake ids using Twitter's snowflake epoch
  *
  * Which is 2006-03-21 at 20:50:14.000 UTC+0, the time and date of the first tweet ever made {@linkplain https://twitter.com/jack/status/20}
  */
-export class TwitterSnowflake extends Snowflake {
-	public constructor() {
-		super(TwitterSnowflake.Epoch);
-	}
-
-	/**
-	 * Twitter epoch (`2006-03-21T20:50:14.000Z`)
-	 * @see {@linkplain https://twitter.com/jack/status/20}, first tweet ever made
-	 */
-	public static readonly Epoch = 1142974214000n;
-
-	/**
-	 * Deconstructs a snowflake given a snowflake ID
-	 * @param id the snowflake to deconstruct
-	 * @returns a deconstructed snowflake
-	 * @example
-	 * ```typescript
-	 * const snowflake = TwitterSnowflake.decode('3971046231244935168');
-	 * ```
-	 */
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	public static decode = TwitterSnowflake.deconstruct;
-
-	/**
-	 * Deconstructs a snowflake given a snowflake ID
-	 * @param id the snowflake to deconstruct
-	 * @returns a deconstructed snowflake
-	 * @example
-	 * ```typescript
-	 * const snowflake = TwitterSnowflake.deconstruct('3971046231244935168');
-	 * ```
-	 */
-	public static deconstruct(id: string | bigint): DeconstructedSnowflake {
-		return new TwitterSnowflake().deconstruct(id);
-	}
-
-	/**
-	 * Generates a snowflake given an epoch and optionally a timestamp
-	 * @param options options to pass into the generator, see {@link SnowflakeGenerateOptions}
-	 *
-	 * **note** when increment is not provided it defaults to `0n`
-	 * @example
-	 * ```typescript
-	 * const snowflake = TwitterSnowflake.generate();
-	 * ```
-	 * @returns A unique snowflake
-	 */
-	public static generate(options: SnowflakeGenerateOptions = { timestamp: Date.now() }) {
-		return new TwitterSnowflake().generate(options);
-	}
-}
+export const TwitterSnowflake = new Snowflake(1142974214000n);

--- a/packages/snowflake/tests/lib/DiscordSnowflake.test.ts
+++ b/packages/snowflake/tests/lib/DiscordSnowflake.test.ts
@@ -12,18 +12,10 @@ describe('Discord Snowflakes', () => {
 
 	describe('Generate', () => {
 		test('GIVEN basic code THEN generates snowflake', () => {
-			const testID = '661720242585735168';
-			const snowflake = new DiscordSnowflake();
-			const snow = snowflake.generate();
-
-			expect(snow.toString()).toBe(testID);
-		});
-
-		test('GIVEN basic code THEN generates snowflake using static method', () => {
-			const testID = '661720242585735168';
+			const testId = '661720242585604096';
 			const snow = DiscordSnowflake.generate();
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 	});
 
@@ -34,8 +26,8 @@ describe('Discord Snowflakes', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 661720242585735168n,
 				timestamp: 1577836800000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 0n,
 				epoch: 1420070400000n
 			});
@@ -47,8 +39,8 @@ describe('Discord Snowflakes', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 661720242585735168n,
 				timestamp: 1577836800000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 0n,
 				epoch: 1420070400000n
 			});

--- a/packages/snowflake/tests/lib/Snowflake.test.ts
+++ b/packages/snowflake/tests/lib/Snowflake.test.ts
@@ -15,58 +15,67 @@ describe('Snowflake', () => {
 
 	describe('Generate', () => {
 		test('GIVEN timestamp as number THEN returns predefined snowflake', () => {
-			const testID = '3971046231244935168';
+			const testId = '3971046231244804096';
 			const testTimestamp = 2524608000000;
 			const snowflake = new Snowflake(sampleEpoch);
 			const snow = snowflake.generate({ timestamp: testTimestamp });
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 
 		test('GIVEN timestamp as Date THEN returns predefined snowflake', () => {
-			const testID = '3971046231244935168';
+			const testId = '3971046231244804096';
 			const testDate = new Date(2524608000000);
 			const snowflake = new Snowflake(sampleEpoch);
 			const snow = snowflake.generate({ timestamp: testDate });
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 
 		test('GIVEN timestamp as Date and increment higher than 4095n THEN returns predefined snowflake', () => {
-			const testID = '3971046231244935168';
+			const testId = '3971046231244804096';
 			const testDate = new Date(2524608000000);
 			const snowflake = new Snowflake(sampleEpoch);
 			const snow = snowflake.generate({ timestamp: testDate, increment: 5000n });
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 
 		test('GIVEN empty object options THEN returns predefined snowflake', () => {
-			const testID = '135168';
+			const testId = '4096';
 			const snowflake = new Snowflake(sampleEpoch);
 			const snow = snowflake.generate({});
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 
 		test('GIVEN no options THEN returns predefined snowflake', () => {
-			const testID = '135168';
+			const testId = '4096';
 			const snowflake = new Snowflake(sampleEpoch);
 			const snow = snowflake.generate({});
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 
 		test('GIVEN timestamp as NaN THEN returns error', () => {
+			const bigIntNaNErrorMessage = (() => {
+				try {
+					BigInt(NaN);
+					throw new RangeError('');
+				} catch (error) {
+					return (error as RangeError).message;
+				}
+			})();
+
 			const snowflake = new Snowflake(sampleEpoch);
-			expect(() => snowflake.generate({ timestamp: NaN })).toThrowError('"timestamp" argument must be a number, BigInt or Date (received NaN)');
+			expect(() => snowflake.generate({ timestamp: NaN })).toThrowError(bigIntNaNErrorMessage);
 		});
 
 		test('GIVEN timestamp as boolean THEN returns error', () => {
 			const snowflake = new Snowflake(sampleEpoch);
 			// @ts-expect-error testing fail case
 			expect(() => snowflake.generate({ timestamp: true })).toThrowError(
-				'"timestamp" argument must be a number, BigInt or Date (received boolean)'
+				'"timestamp" argument must be a number, bigint, or Date (received boolean)'
 			);
 		});
 
@@ -91,6 +100,22 @@ describe('Snowflake', () => {
 			// Validate that there are no duplicate IDs
 			expect(setOf10Snowflakes.size).toBe(arrayOf10Snowflakes.length);
 		});
+
+		test('GIVEN overflowing processId THEN generates ID with truncated processId', () => {
+			const testId = '106496';
+			const snowflake = new Snowflake(sampleEpoch);
+			const snow = snowflake.generate({ processId: 0b1111_1010n });
+
+			expect(snow.toString()).toBe(testId);
+		});
+
+		test('GIVEN overflowing workerId THEN generates ID with truncated workerId', () => {
+			const testId = '3411968';
+			const snowflake = new Snowflake(sampleEpoch);
+			const snow = snowflake.generate({ workerId: 0b1111_1010n });
+
+			expect(snow.toString()).toBe(testId);
+		});
 	});
 
 	describe('Deconstruct', () => {
@@ -102,8 +127,8 @@ describe('Snowflake', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 3971046231244935169n,
 				timestamp: 2524608000000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 1n,
 				epoch: 1577836800000n
 			});
@@ -117,8 +142,8 @@ describe('Snowflake', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 3971046231244935168n,
 				timestamp: 2524608000000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 0n,
 				epoch: 1577836800000n
 			});
@@ -134,8 +159,8 @@ describe('Snowflake', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 3971046231244935169n,
 				timestamp: 2524608000000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 1n,
 				epoch: 1577836800000n
 			});
@@ -149,8 +174,8 @@ describe('Snowflake', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 3971046231244935168n,
 				timestamp: 2524608000000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 0n,
 				epoch: 1577836800000n
 			});

--- a/packages/snowflake/tests/lib/TwitterSnowflake.test.ts
+++ b/packages/snowflake/tests/lib/TwitterSnowflake.test.ts
@@ -12,18 +12,10 @@ describe('Twitter Snowflakes', () => {
 
 	describe('Generate', () => {
 		test('GIVEN basic code THEN generates snowflake', () => {
-			const testID = '1823945883910279168';
-			const snowflake = new TwitterSnowflake();
-			const snow = snowflake.generate();
-
-			expect(snow.toString()).toBe(testID);
-		});
-
-		test('GIVEN basic code THEN generates snowflake using static method', () => {
-			const testID = '1823945883910279168';
+			const testId = '1823945883910148096';
 			const snow = TwitterSnowflake.generate();
 
-			expect(snow.toString()).toBe(testID);
+			expect(snow.toString()).toBe(testId);
 		});
 	});
 
@@ -34,8 +26,8 @@ describe('Twitter Snowflakes', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 1823945883910279168n,
 				timestamp: 1577836800000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 0n,
 				epoch: 1142974214000n
 			});
@@ -47,8 +39,8 @@ describe('Twitter Snowflakes', () => {
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 1823945883910279168n,
 				timestamp: 1577836800000n,
-				workerID: 1n,
-				processID: 1n,
+				workerId: 1n,
+				processId: 1n,
 				increment: 0n,
 				epoch: 1142974214000n
 			});


### PR DESCRIPTION
- **fix**: limit range of `processId` to 5 bits
- **fix**: limit range of `workerId` to 5 bits
- **feat**: added `epoch` getter
- **feat**: added `timestampFrom` method
- **feat**: default `processId` to `process.pid`
- **feat**: default `workerId` to `worker_threads.threadId`
- **refactor**: improved performance and reduced amount of checks
- :warning: **BREAKING CHANGE**: Renamed `processID` to `processId`
- :warning: **BREAKING CHANGE**: Renamed `workerID` to `workerId`
- :warning: **BREAKING CHANGE**: `processId` not longer defaults to 1n (outside NODE_ENV = test)
- :warning: **BREAKING CHANGE**: `workerId` not longer defaults to 1n (outside NODE_ENV = test)
- :warning: **BREAKING CHANGE**: `DiscordSnowflake` is not longer a class, but a constructed Snowflake
- :warning: **BREAKING CHANGE**: `TwitterSnowflake` is not longer a class, but a constructed Snowflake
