### PR TITLE
feat(event-iterator): do not bundle for browsers

### DIFF
--- a/packages/event-iterator/package.json
+++ b/packages/event-iterator/package.json
@@ -6,8 +6,6 @@
 	"license": "MIT",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
-	"browser": "dist/index.umd.js",
-	"unpkg": "dist/index.umd.js",
 	"types": "dist/index.d.ts",
 	"typedocMain": "src/index.ts",
 	"exports": {
@@ -19,9 +17,12 @@
 	"scripts": {
 		"test": "jest",
 		"lint": "eslint src tests --ext ts --fix -c ../../.eslintrc",
-		"build": "rollup -c",
+		"build": "tsc -b src && gen-esm-wrapper dist/index.js dist/index.mjs",
 		"start": "yarn build -w",
 		"prepublishOnly": "yarn build"
+	},
+	"dependencies": {
+		"tslib": "^2.3.1"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/event-iterator/rollup.config.js
+++ b/packages/event-iterator/rollup.config.js
@@ -1,3 +1,0 @@
-import baseConfig from '../../scripts/rollup.config';
-
-export default baseConfig({ umdName: 'SapphireEventIterator' });

--- a/packages/event-iterator/src/index.ts
+++ b/packages/event-iterator/src/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/explicit-member-accessibility */
-import type { EventEmitter } from 'events';
+import type { EventEmitter } from 'node:events';
 
 /**
  * A filter for an EventIterator.

--- a/packages/event-iterator/src/tsconfig.json
+++ b/packages/event-iterator/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
-		"target": "ES2020",
 		"rootDir": "./",
 		"outDir": "../dist",
 		"tsBuildInfoFile": "../dist/.tsbuildinfo",

--- a/packages/event-iterator/tests/lib/MockEmitter.ts
+++ b/packages/event-iterator/tests/lib/MockEmitter.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/explicit-member-accessibility */
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { EventIterator, EventIteratorOptions } from '../../src';
 import { Person } from './Person';
 

--- a/packages/event-iterator/tests/tsconfig.json
+++ b/packages/event-iterator/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
-		"target": "ES2020",
 		"rootDir": "./",
 		"outDir": "./build",
 		"tsBuildInfoFile": "./build/.tsbuildinfo"

--- a/packages/event-iterator/tsconfig.json
+++ b/packages/event-iterator/tsconfig.json
@@ -1,10 +1,11 @@
 {
 	"extends": "../ts-config/src/tsconfig.json",
 	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
 		"outDir": "build",
-		"rootDir": "src"
+		"rootDir": "src",
+		"composite": true,
+		"tsBuildInfoFile": "./dist/.tsbuildinfo",
+		"useDefineForClassFields": false
 	},
 	"include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,6 +2121,8 @@ __metadata:
 "@sapphire/event-iterator@workspace:packages/event-iterator":
   version: 0.0.0-use.local
   resolution: "@sapphire/event-iterator@workspace:packages/event-iterator"
+  dependencies:
+    tslib: ^2.3.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Not sure why we ever even did because there is no `EventEmitter` in browsers which AFAIK this relies on.
