### PR TITLE
fix(utilities): make `NonNullObject` require object

### DIFF
--- a/packages/utilities/src/lib/utilityTypes.ts
+++ b/packages/utilities/src/lib/utilityTypes.ts
@@ -94,7 +94,8 @@ export type NonNullableProperties<T = unknown> = {
 /**
  * An object that is non nullable, to bypass TypeScript not easily working with {@link Record}<{@link PropertyKey}, unknown> in various instances.
  */
-export interface NonNullObject {}
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NonNullObject = {} & object;
 
 /**
  * Gets all the keys (as a string union) from a type `T` that match value `V`


### PR DESCRIPTION
The `{}` type allowed any value (even numbers and strings), which wasn't different to `unknown` except that it required non-null. By doing an union (`{} & object`), the type is required to be both an object and non-null.
