### PR TITLE
feat(discord.js-utilities): add `PaginatedMessageEmbedFields`

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@sapphire/utilities';
 import { MessageEmbed, MessageEmbedOptions } from 'discord.js';
 import { PaginatedMessage } from './PaginatedMessage';
 
@@ -82,8 +83,8 @@ export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
 	 * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message);
 	 * ```
 	 */
-	public setTemplate(template: MessageEmbedOptions | MessageEmbed) {
-		this.embedTemplate = template instanceof MessageEmbed ? template : new MessageEmbed(template);
+	public setTemplate(template: MessageEmbedOptions | MessageEmbed | ((embed: MessageEmbed) => MessageEmbed)) {
+		this.embedTemplate = this.resolveTemplate(template);
 		return this;
 	}
 
@@ -164,5 +165,17 @@ export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
 	private paginateArray(items: T[], currentPage: number, perPageItems: number) {
 		const offset = currentPage * perPageItems;
 		return items.slice(offset, offset + perPageItems);
+	}
+
+	private resolveTemplate(template: MessageEmbed | MessageEmbedOptions | ((embed: MessageEmbed) => MessageEmbed)) {
+		if (template instanceof MessageEmbed) {
+			return template;
+		}
+
+		if (isFunction(template)) {
+			return template(new MessageEmbed());
+		}
+
+		return new MessageEmbed(template);
 	}
 }

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
@@ -2,8 +2,12 @@ import { MessageEmbed, MessageEmbedOptions } from 'discord.js';
 import { PaginatedMessage } from './PaginatedMessage';
 
 /**
- * This is a utility of {@link PaginatedMessage}, except it exclusively paginates the fields of an embed.
+ * This is a utility of {@link PaginatedMessage}, except it exclusively adds pagination inside a field of an embed.
  * You must either use this class directly or extend it.
+ *
+ * It differs from PaginatedMessageEmbedFields as the items here are the shape you want, and are then concatenated
+ * in a single field with a given formatter function, whereas PaginatedMessageEmbedFields takes fields as the items
+ * and add them to the embed.
  *
  * @example
  * ```typescript
@@ -67,7 +71,7 @@ export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
 	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
 	 * import { MessageEmbed } from 'discord.js';
 	 *
-	 * new PaginatedFieldMessageEmbed().setTemplate(new MessageEmbed().setTitle('Test pager embed')).make().run(message.author, message.channel);
+	 * new PaginatedFieldMessageEmbed().setTemplate(new MessageEmbed().setTitle('Test pager embed')).make().run(message);
 	 * ```
 	 *
 	 * @example
@@ -75,7 +79,7 @@ export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
 	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
 	 * import { MessageEmbed } from 'discord.js';
 	 *
-	 * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message.author, message.channel);
+	 * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message);
 	 * ```
 	 */
 	public setTemplate(template: MessageEmbedOptions | MessageEmbed) {

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
@@ -1,0 +1,148 @@
+import { EmbedLimits } from '@sapphire/discord-utilities';
+import { isFunction } from '@sapphire/utilities';
+import { EmbedFieldData, MessageEmbed, MessageEmbedOptions } from 'discord.js';
+import { PaginatedMessage } from './PaginatedMessage';
+
+/**
+ * This is a utility of {@link PaginatedMessage}, except it exclusively paginates the fields of an embed.
+ * You must either use this class directly or extend it.
+ *
+ * It differs from PaginatedFieldMessageEmbed as the items here are whole fields, that are added to the embed,
+ * whereas PaginatedFieldMessageEmbed concatenates the items in a single field with a given formatter function.
+ *
+ * @example
+ * ```typescript
+ * import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities';
+ *
+ * new PaginatedMessageEmbedFields()
+ * 	.setTemplate({ title: 'Test pager embed', color: '#006080' })
+ * 	.setItems([
+ * 		{ title: 'Sapphire Framework', value: 'discord.js Framework' },
+ * 		{ title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
+ * 		{ title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
+ * 	])
+ * 	.setItemsPerPage(2)
+ * 	.make()
+ * 	.run(message);
+ * ```
+ */
+export default class PaginatedMessageEmbedFields extends PaginatedMessage {
+	private embedTemplate: MessageEmbed = new MessageEmbed();
+	private totalPages = 0;
+	private items: EmbedFieldData[] = [];
+	private itemsPerPage = 10;
+
+	/**
+	 * Set the items to paginate.
+	 * @param items The pages to set
+	 */
+	public setItems(items: EmbedFieldData[]): this {
+		this.items = items;
+		return this;
+	}
+
+	/**
+	 * Sets the amount of items that should be shown per page.
+	 * @param itemsPerPage The number of items
+	 */
+	public setItemsPerPage(itemsPerPage: number): this {
+		this.itemsPerPage = itemsPerPage;
+		return this;
+	}
+
+	/**
+	 * Sets the template to be used to display the embed fields as pages. This template can either be set from a template {@link MessageEmbed} instance or an object with embed options.
+	 * All fields in the given template will be overwritten when calling {@link PaginatedMessageEmbedFields.make}.
+	 *
+	 * @param template MessageEmbed
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities';
+	 * import { MessageEmbed } from 'discord.js';
+	 *
+	 * new PaginatedMessageEmbedFields()
+	 * 	.setTemplate(new MessageEmbed().setColor('#006080').setTitle('Test pager embed'))
+	 * 	.setItems([{ name: 'My field', value: 'The field\'s value' }])
+	 * 	.make()
+	 * 	.run(message);
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities';
+	 * import { MessageEmbed } from 'discord.js';
+	 *
+	 * new PaginatedMessageEmbedFields()
+	 * 	.setTemplate({ title: 'Test pager embed', color: '#006080' })
+	 * 	.setItems([{ name: 'My field', value: 'The field\'s value' }])
+	 * 	.make()
+	 * 	.run(message);
+	 * ```
+	 */
+	public setTemplate(template: MessageEmbed | MessageEmbedOptions | ((embed: MessageEmbed) => MessageEmbed)): this {
+		this.embedTemplate = this.resolveTemplate(template);
+		return this;
+	}
+
+	/**
+	 * Build the pages of the given array.
+	 *
+	 * You must call the [[PaginatedMessageEmbedFields.make]] and [[PaginatedMessageEmbedFields.run]] methods last, in that order, for the pagination to work.
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities';
+	 *
+	 * new PaginatedMessageEmbedFields()
+	 * 	.setItems([
+	 * 		{ title: 'Sapphire Framework', value: 'discord.js Framework' },
+	 * 		{ title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
+	 * 		{ title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
+	 * 	])
+	 * 	.setItemsPerPage(3)
+	 * 	.make()
+	 * 	.run(message);
+	 * ```
+	 */
+	public make(): this {
+		if (!this.items.length) throw new Error('The items array is empty.');
+		if (this.itemsPerPage > EmbedLimits.MaximumFields) throw new Error(`Pages cannot contain more than ${EmbedLimits.MaximumFields} fields.`);
+
+		this.totalPages = Math.ceil(this.items.length / this.itemsPerPage);
+		this.generatePages();
+		return this;
+	}
+
+	private generatePages(): void {
+		const template = this.embedTemplate instanceof MessageEmbed ? (this.embedTemplate.toJSON() as MessageEmbedOptions) : this.embedTemplate;
+		for (let i = 0; i < this.totalPages; i++) {
+			const clonedTemplate = new MessageEmbed(template);
+			clonedTemplate.fields = [];
+
+			if (!clonedTemplate.color) clonedTemplate.setColor('RANDOM');
+
+			const data = this.paginateArray(this.items, i, this.itemsPerPage);
+			this.addPage({
+				embeds: [clonedTemplate.addFields(...data)]
+			});
+		}
+	}
+
+	private paginateArray(items: EmbedFieldData[], currentPage: number, perPageItems: number): EmbedFieldData[] {
+		const offset = currentPage * perPageItems;
+		return items.slice(offset, offset + perPageItems);
+	}
+
+	private resolveTemplate(template: MessageEmbed | MessageEmbedOptions | ((embed: MessageEmbed) => MessageEmbed)) {
+		if (template instanceof MessageEmbed) {
+			return template;
+		}
+
+		if (isFunction(template)) {
+			return template(new MessageEmbed());
+		}
+
+		return new MessageEmbed(template);
+	}
+}


### PR DESCRIPTION
`PaginatedMessageEmbedFields` (this new one) differs from `PaginatedFieldMessageEmbed` (Kanama's one) as the items here are whole fields, that are added to the embed, whereas `PaginatedFieldMessageEmbed` concatenates the items in a single field with a given formatter function.

I believe this one is quite useful too and will find its lot of users.