### PR TITLE
feat(decorators): add container to `ApplyOptions` callback

### DIFF
--- a/packages/decorators/src/piece-decorators.ts
+++ b/packages/decorators/src/piece-decorators.ts
@@ -1,4 +1,5 @@
-import type { Piece, PieceContext, PieceOptions } from '@sapphire/framework';
+import { container, type Piece, type PieceContext, type PieceOptions } from '@sapphire/framework';
+import type { Container } from '@sapphire/pieces';
 import type { Ctor } from '@sapphire/utilities';
 import { createClassDecorator, createProxy } from './utils';
 
@@ -7,32 +8,56 @@ import { createClassDecorator, createProxy } from './utils';
  * @param options The options to pass to the piece constructor
  * @example
  * ```typescript
- * import { ApplyOptions } from '@sapphire/decorators';
- * import { Command, CommandOptions } from '@sapphire/framework';
- * import type { Message } from 'discord.js';
+ * import { ApplyOptions } from "@sapphire/decorators";
+ * import { Command } from "@sapphire/framework";
+ * import type { Message } from "discord.js";
  *
- * (at)ApplyOptions<CommandOptions>({
- * 	description: 'ping pong',
- * 	enabled: true
+ * (at)ApplyOptions<Command.Options>({
+ *   description: "ping pong",
+ *   enabled: true,
  * })
  * export class UserCommand extends Command {
- * 	public async messageRun(message: Message) {
- * 		const msg = await message.channel.send('Ping?');
+ *   public async messageRun(message: Message) {
+ *     const msg = await message.channel.send("Ping?");
  *
- * 		return msg.edit(
- * 			`Pong! Client Latency ${Math.round(this.context.client.ws.ping)}ms. API Latency ${msg.createdTimestamp - message.createdTimestamp}ms.`
- * 		);
- * 	}
+ *     return msg.edit(
+ *       `Pong! Client Latency ${Math.round(this.container.client.ws.ping)}ms. API Latency ${
+ *         msg.createdTimestamp - message.createdTimestamp
+ *       }ms.`
+ *     );
+ *   }
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * import { ApplyOptions } from "@sapphire/decorators";
+ * import { Listener } from "@sapphire/framework";
+ * import { GatewayDispatchEvents, GatewayMessageDeleteDispatch } from "discord-api-types/v9";
+ *
+ * (at)ApplyOptions<Listener.Options>((container) => ({
+ *   description: "Handle Raw Message Delete events",
+ *   emitter: container.client.ws,
+ *   event: GatewayDispatchEvents.MessageDelete,
+ * }))
+ * export class UserListener extends Listener {
+ *   public run(data: GatewayMessageDeleteDispatch["d"]): void {
+ *     if (!data.guild_id) return;
+ *
+ *     const guild = this.container.client.guilds.cache.get(data.guild_id);
+ *     if (!guild || !guild.channels.cache.has(data.channel_id)) return;
+ *
+ *     // Do something with the data
+ *   }
  * }
  * ```
  */
-export function ApplyOptions<T extends PieceOptions>(optionsOrFn: T | ((context: PieceContext) => T)): ClassDecorator {
+export function ApplyOptions<T extends PieceOptions>(optionsOrFn: T | ((container: Container, context: PieceContext) => T)): ClassDecorator {
 	return createClassDecorator((target: Ctor<ConstructorParameters<typeof Piece>, Piece>) =>
 		createProxy(target, {
 			construct: (ctor, [context, baseOptions = {}]) =>
 				new ctor(context, {
 					...baseOptions,
-					...(typeof optionsOrFn === 'function' ? optionsOrFn(context) : optionsOrFn)
+					...(typeof optionsOrFn === 'function' ? optionsOrFn(container, context) : optionsOrFn)
 				})
 		})
 	);

--- a/packages/decorators/src/piece-decorators.ts
+++ b/packages/decorators/src/piece-decorators.ts
@@ -1,4 +1,4 @@
-import { container, type Piece, type PieceContext, type PieceOptions } from '@sapphire/framework';
+import { container, type Piece } from '@sapphire/framework';
 import type { Container } from '@sapphire/pieces';
 import type { Ctor } from '@sapphire/utilities';
 import { createClassDecorator, createProxy } from './utils';
@@ -49,12 +49,10 @@ import { createClassDecorator, createProxy } from './utils';
  * }
  * ```
  */
-export function ApplyOptions<T extends PieceOptions>(
-	optionsOrFn: T | (({ container, context }: ApplyOptionsCallbackParameters) => T)
-): ClassDecorator {
+export function ApplyOptions<T extends Piece.Options>(optionsOrFn: T | ((parameters: ApplyOptionsCallbackParameters) => T)): ClassDecorator {
 	return createClassDecorator((target: Ctor<ConstructorParameters<typeof Piece>, Piece>) =>
 		createProxy(target, {
-			construct: (ctor, [context, baseOptions = {}]) =>
+			construct: (ctor, [context, baseOptions = {}]: [Piece.Context, Piece.Options]) =>
 				new ctor(context, {
 					...baseOptions,
 					...(typeof optionsOrFn === 'function' ? optionsOrFn({ container, context }) : optionsOrFn)
@@ -65,5 +63,5 @@ export function ApplyOptions<T extends PieceOptions>(
 
 export interface ApplyOptionsCallbackParameters {
 	container: Container;
-	context: PieceContext;
+	context: Piece.Context;
 }

--- a/packages/decorators/src/piece-decorators.ts
+++ b/packages/decorators/src/piece-decorators.ts
@@ -32,7 +32,7 @@ import { createClassDecorator, createProxy } from './utils';
  * import { Listener } from '@sapphire/framework';
  * import { GatewayDispatchEvents, GatewayMessageDeleteDispatch } from 'discord-api-types/v9';
  *
- * @ApplyOptions<Listener.Options>((container) => ({
+ * @ApplyOptions<Listener.Options>(({ container }) => ({
  *   description: 'Handle Raw Message Delete events',
  *   emitter: container.client.ws,
  *   event: GatewayDispatchEvents.MessageDelete
@@ -49,14 +49,21 @@ import { createClassDecorator, createProxy } from './utils';
  * }
  * ```
  */
-export function ApplyOptions<T extends PieceOptions>(optionsOrFn: T | ((container: Container, context: PieceContext) => T)): ClassDecorator {
+export function ApplyOptions<T extends PieceOptions>(
+	optionsOrFn: T | (({ container, context }: ApplyOptionsCallbackParameters) => T)
+): ClassDecorator {
 	return createClassDecorator((target: Ctor<ConstructorParameters<typeof Piece>, Piece>) =>
 		createProxy(target, {
 			construct: (ctor, [context, baseOptions = {}]) =>
 				new ctor(context, {
 					...baseOptions,
-					...(typeof optionsOrFn === 'function' ? optionsOrFn(container, context) : optionsOrFn)
+					...(typeof optionsOrFn === 'function' ? optionsOrFn({ container, context }) : optionsOrFn)
 				})
 		})
 	);
+}
+
+export interface ApplyOptionsCallbackParameters {
+	container: Container;
+	context: PieceContext;
 }

--- a/packages/decorators/src/piece-decorators.ts
+++ b/packages/decorators/src/piece-decorators.ts
@@ -38,7 +38,7 @@ import { createClassDecorator, createProxy } from './utils';
  *   event: GatewayDispatchEvents.MessageDelete
  * }))
  * export class UserListener extends Listener {
- *   public run(data: GatewayMessageDeleteDispatch['d']): void {
+ *   public override run(data: GatewayMessageDeleteDispatch['d']): void {
  *     if (!data.guild_id) return;
  *
  *     const guild = this.container.client.guilds.cache.get(data.guild_id);

--- a/packages/decorators/src/piece-decorators.ts
+++ b/packages/decorators/src/piece-decorators.ts
@@ -8,39 +8,37 @@ import { createClassDecorator, createProxy } from './utils';
  * @param options The options to pass to the piece constructor
  * @example
  * ```typescript
- * import { ApplyOptions } from "@sapphire/decorators";
- * import { Command } from "@sapphire/framework";
- * import type { Message } from "discord.js";
+ * import { ApplyOptions } from '@sapphire/decorators';
+ * import { Command } from '@sapphire/framework';
+ * import type { Message } from 'discord.js';
  *
- * (at)ApplyOptions<Command.Options>({
- *   description: "ping pong",
- *   enabled: true,
+ * @ApplyOptions<Command.Options>({
+ *   description: 'ping pong',
+ *   enabled: true
  * })
  * export class UserCommand extends Command {
- *   public async messageRun(message: Message) {
- *     const msg = await message.channel.send("Ping?");
+ *   public override async messageRun(message: Message) {
+ *     const msg = await message.channel.send('Ping?');
  *
  *     return msg.edit(
- *       `Pong! Client Latency ${Math.round(this.container.client.ws.ping)}ms. API Latency ${
- *         msg.createdTimestamp - message.createdTimestamp
- *       }ms.`
+ *       `Pong! Client Latency ${Math.round(this.container.client.ws.ping)}ms. API Latency ${msg.createdTimestamp - message.createdTimestamp}ms.`
  *     );
  *   }
  * }
  * ```
  * @example
  * ```typescript
- * import { ApplyOptions } from "@sapphire/decorators";
- * import { Listener } from "@sapphire/framework";
- * import { GatewayDispatchEvents, GatewayMessageDeleteDispatch } from "discord-api-types/v9";
+ * import { ApplyOptions } from '@sapphire/decorators';
+ * import { Listener } from '@sapphire/framework';
+ * import { GatewayDispatchEvents, GatewayMessageDeleteDispatch } from 'discord-api-types/v9';
  *
- * (at)ApplyOptions<Listener.Options>((container) => ({
- *   description: "Handle Raw Message Delete events",
+ * @ApplyOptions<Listener.Options>((container) => ({
+ *   description: 'Handle Raw Message Delete events',
  *   emitter: container.client.ws,
- *   event: GatewayDispatchEvents.MessageDelete,
+ *   event: GatewayDispatchEvents.MessageDelete
  * }))
  * export class UserListener extends Listener {
- *   public run(data: GatewayMessageDeleteDispatch["d"]): void {
+ *   public run(data: GatewayMessageDeleteDispatch['d']): void {
  *     if (!data.guild_id) return;
  *
  *     const guild = this.container.client.guilds.cache.get(data.guild_id);


### PR DESCRIPTION
BREAKING CHANGE: When using `@ApplyOptions` with a callback function, the single parameter of `PieceContex` been changed to an object, which also has a property of `Container`. Migration change is `@ApplyOptions<Listener.Options>(({ context }) => ({`