### PR TITLE
feat(PaginatedMessage): made it possible to add custom `link` buttons with `setActions` / `addActions` / `addAction`

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -5,6 +5,7 @@ import type {
 	Guild,
 	InteractionButtonOptions,
 	InteractionCollector,
+	LinkButtonOptions,
 	Message,
 	MessageComponentInteraction,
 	MessageEmbed,
@@ -21,21 +22,13 @@ import type {
 import type { MessageButtonStyles, MessageComponentTypes } from 'discord.js/typings/enums';
 import type { PaginatedMessage } from './PaginatedMessage';
 
+export type PaginatedMessageAction = PaginatedMessageActionButton | PaginatedMessageActionLink | PaginatedMessageActionMenu;
+
 /**
- * To utilize actions you can use the {@link PaginatedMessageAction} by implementing it into a class.
+ * To utilize buttons you can pass an object with the structure of {@link PaginatedMessageActionButton} to {@link PaginatedMessage} actions.
  * @example
  * ```typescript
- * class ForwardAction implements IPaginatedMessageAction {
- *   public id = '▶️';
- *
- *   public run({ handler }) {
- *     if (handler.index !== handler.pages.length - 1) ++handler.index;
- *   }
- * }
- *
- * // You can also give the object directly.
- *
- * const StopAction: IPaginatedMessageAction {
+ * const StopAction: PaginatedMessageActionButton {
  *   customId: 'CustomStopAction',
  *   emoji: '⏹️',
  *   run: ({ collector }) => {
@@ -44,15 +37,49 @@ import type { PaginatedMessage } from './PaginatedMessage';
  * }
  * ```
  */
-export interface PaginatedMessageAction extends Omit<InteractionButtonOptions, 'customId' | 'style'>, Omit<MessageSelectMenuOptions, 'customId'> {
+export interface PaginatedMessageActionButton extends Omit<InteractionButtonOptions, 'customId' | 'style'> {
 	customId: string;
-	type: MessageComponentTypes;
-	style?: ExcludeEnum<typeof MessageButtonStyles, 'LINK'>;
+	type: ExcludeEnum<typeof MessageComponentTypes, 'SELECT_MENU' | 'ACTION_ROW'>;
+	style: ExcludeEnum<typeof MessageButtonStyles, 'LINK'>;
 	run(context: PaginatedMessageActionContext): Awaitable<unknown>;
 }
 
 /**
- * The context to be used in {@link PaginatedMessageAction}.
+ * To utilize links you can pass an object with the structure of {@link PaginatedMessageActionLink} to {@link PaginatedMessage} actions.
+ * @example
+ * ```typescript
+ *  You can also give the object directly.
+ *
+ * const LinkSapphireJs: PaginatedMessageActionLink {
+ *   url: 'https://sapphirejs.dev',
+ *   label: 'Sapphire Website',
+ *   emoji: '🔗'
+ * }
+ * ```
+ */
+export interface PaginatedMessageActionLink extends LinkButtonOptions {
+	type: ExcludeEnum<typeof MessageComponentTypes, 'SELECT_MENU' | 'ACTION_ROW'>;
+}
+
+/**
+ * To utilize Select Menus you can pass an object with the structure of {@link PaginatedMessageActionMenu} to {@link PaginatedMessage} actions.
+ * @example
+ * ```typescript
+ * const StopAction: PaginatedMessageActionMenu {
+ *   customId: 'CustomSelectMenu',
+ *   type: Constants.MessageComponentTypes.SELECT_MENU,
+ *   run: ({ handler, interaction }) => interaction.isSelectMenu() && (handler.index = parseInt(interaction.values[0], 10))
+ * }
+ * ```
+ */
+export interface PaginatedMessageActionMenu extends Omit<MessageSelectMenuOptions, 'customId'> {
+	customId: string;
+	type: ExcludeEnum<typeof MessageComponentTypes, 'BUTTON' | 'ACTION_ROW'>;
+	run(context: PaginatedMessageActionContext): Awaitable<unknown>;
+}
+
+/**
+ * The context to be used in {@link PaginatedMessageActionButton}.
  */
 export interface PaginatedMessageActionContext {
 	interaction: ButtonInteraction | SelectMenuInteraction;
@@ -71,7 +98,7 @@ export interface PaginatedMessageOptions {
 	/**
 	 * Custom actions to provide when sending the paginated message
 	 */
-	actions?: PaginatedMessageAction[];
+	actions?: PaginatedMessageActionButton[];
 	/**
 	 * The {@link MessageEmbed} or {@link MessageOptions} options to apply to the entire {@link PaginatedMessage}
 	 */

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -1,5 +1,14 @@
 import { chunk, partition } from '@sapphire/utilities';
 import { Constants, InteractionButtonOptions, MessageActionRow, MessageButton, MessageSelectMenu, MessageSelectMenuOptions } from 'discord.js';
+import type { PaginatedMessageAction, PaginatedMessageActionButton, PaginatedMessageActionLink, PaginatedMessageActionMenu } from '.';
+
+export function actionIsButtonOrMenu(action: PaginatedMessageAction): action is PaginatedMessageActionButton | PaginatedMessageActionMenu {
+	return (
+		action.type === Constants.MessageComponentTypes.SELECT_MENU ||
+		((action as PaginatedMessageActionButton | PaginatedMessageActionLink).style !== 'LINK' &&
+			(action as PaginatedMessageActionButton | PaginatedMessageActionLink).style !== Constants.MessageButtonStyles.LINK)
+	);
+}
 
 export function isMessageButtonInteraction(
 	interaction: InteractionButtonOptions | MessageSelectMenuOptions


### PR DESCRIPTION
This makes it possible to add `LINK` style buttons to the paginated message's actions.
Previously it was set up to lock out this possibility.
I probably had some issues implementing it in a sensible way and gave up, I don't remember.

I also made it possible to set a second optional parameter of `setActions` to true
to have the library merge in `PaginatedMessage.defaultActions`, something that is a
common use case when using this particular function.
This change will save users from having to manually add the default actions.

I'm not sure if this change should be considered `semver:major`. @vladfrangu what do you say?
I'm primarily asking because `PaginatedMessageAction` was changed from an `interface` to a `type`
which subsequently caused this issue at least in Skyra's code:

![](https://media.discordapp.net/attachments/759750007087431721/931976453879373864/unknown.png?width=1440&height=223)

Easily fixed of course by just changing it to a `type`, but the code did not compile.
Is that `semver:major`?

```typescript
type HelpPaginatedMessageAction = PaginatedMessageAction & {
	selectMenuIndex?: 'set-1' | 'set-2';
};
```
