### PR TITLE
feat(PaginatedMessage): add support for interactions

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
@@ -1,5 +1,5 @@
 import { isFunction } from '@sapphire/utilities';
-import { MessageEmbed, MessageEmbedOptions } from 'discord.js';
+import { MessageEmbed, type MessageEmbedOptions } from 'discord.js';
 import { PaginatedMessage } from './PaginatedMessage';
 
 /**

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -719,7 +719,7 @@ export class PaginatedMessage {
 
 	/**
 	 * Executes the {@link PaginatedMessage} and sends the pages corresponding with {@link PaginatedMessage.index}.
-	 * The handler will start collecting button interactions.
+	 * The handler will start collecting message component interactions.
 	 *
 	 * @param messageOrInteraction The message or interaction that triggered this {@link PaginatedMessage}.
 	 * Generally this will be the command message or an interaction
@@ -744,10 +744,10 @@ export class PaginatedMessage {
 
 			// If the message was sent by a bot, then set the response as this one
 			if (runsOnInteraction(messageOrInteraction)) {
-				if (messageOrInteraction.user.bot) {
+				if (messageOrInteraction.user.bot && messageOrInteraction.user.id === messageOrInteraction.client.user?.id) {
 					this.response = messageOrInteraction;
 				}
-			} else if (messageOrInteraction.author.bot) {
+			} else if (messageOrInteraction.author.bot && messageOrInteraction.author.id === messageOrInteraction.client.user?.id) {
 				this.response = messageOrInteraction;
 			}
 
@@ -891,7 +891,7 @@ export class PaginatedMessage {
 	protected setUpCollector(channel: TextBasedChannel, targetUser: User): void {
 		if (this.pages.length > 1) {
 			this.collector = new InteractionCollector(targetUser.client, {
-				filter: (interaction) => (interaction.isButton() || interaction.isSelectMenu()) && this.actions.has(interaction.customId),
+				filter: (interaction) => interaction.isMessageComponent() && this.actions.has(interaction.customId),
 				time: this.idle,
 				guild: isGuildBasedChannel(channel) ? channel.guild : undefined,
 				channel,
@@ -986,7 +986,7 @@ export class PaginatedMessage {
 			if (runsOnInteraction(this.response)) {
 				if (this.response.replied || this.response.deferred) {
 					void this.response.editReply({ components: [] });
-				} else if (this.response.isSelectMenu()) {
+				} else if (this.response.isMessageComponent()) {
 					void this.response.update({ components: [] });
 				} else {
 					void this.response.reply({ components: [] });
@@ -1137,7 +1137,7 @@ export class PaginatedMessage {
 				if (runsOnInteraction(response)) {
 					if (response.replied || response.deferred) {
 						await response.editReply({ components: [] });
-					} else if (response.isSelectMenu()) {
+					} else if (response.isMessageComponent()) {
 						await response.update({ components: [] });
 					} else {
 						await response.reply({ components: [] });

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -989,7 +989,7 @@ export class PaginatedMessage {
 				} else if (this.response.isMessageComponent()) {
 					void this.response.update({ components: [] });
 				} else {
-					void this.response.reply({ components: [] });
+					void this.response.reply({ content: "This maze wasn't meant for you...what did you do.", ephemeral: true });
 				}
 			} else {
 				void this.response.edit({ components: [] });
@@ -1140,7 +1140,7 @@ export class PaginatedMessage {
 					} else if (response.isMessageComponent()) {
 						await response.update({ components: [] });
 					} else {
-						await response.reply({ components: [] });
+						await response.reply({ content: "This maze wasn't meant for you...what did you do.", ephemeral: true });
 					}
 				} else {
 					await response.edit({ components: [] });

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -10,8 +10,8 @@ import {
 	type ButtonInteraction,
 	type Collection,
 	type CommandInteraction,
-	type Interaction,
 	type Message,
+	type MessageComponentInteraction,
 	type MessageOptions,
 	type SelectMenuInteraction,
 	type Snowflake,
@@ -120,7 +120,7 @@ export class PaginatedMessage {
 	/**
 	 * The collector used for handling component interactions.
 	 */
-	public collector: InteractionCollector<Interaction> | null = null;
+	public collector: InteractionCollector<MessageComponentInteraction> | null = null;
 
 	/**
 	 * The pages which were converted from {@link PaginatedMessage.pages}
@@ -890,7 +890,7 @@ export class PaginatedMessage {
 	 */
 	protected setUpCollector(channel: TextBasedChannel, targetUser: User): void {
 		if (this.pages.length > 1) {
-			this.collector = new InteractionCollector(targetUser.client, {
+			this.collector = new InteractionCollector<MessageComponentInteraction>(targetUser.client, {
 				filter: (interaction) => interaction.isMessageComponent() && this.actions.has(interaction.customId),
 				time: this.idle,
 				guild: isGuildBasedChannel(channel) ? channel.guild : undefined,

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -118,7 +118,7 @@ export class PaginatedMessage {
 	public response: Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction | null = null;
 
 	/**
-	 * The collector used for handling button clicks.
+	 * The collector used for handling component interactions.
 	 */
 	public collector: InteractionCollector<Interaction> | null = null;
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
@@ -1,6 +1,6 @@
 import { EmbedLimits } from '@sapphire/discord-utilities';
 import { isFunction } from '@sapphire/utilities';
-import { EmbedFieldData, MessageEmbed, MessageEmbedOptions } from 'discord.js';
+import { MessageEmbed, type EmbedFieldData, type MessageEmbedOptions } from 'discord.js';
 import { PaginatedMessage } from './PaginatedMessage';
 
 /**

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -1,8 +1,10 @@
 import type { Awaitable } from '@sapphire/utilities';
 import type {
 	ButtonInteraction,
+	CommandInteraction,
 	ExcludeEnum,
 	Guild,
+	Interaction,
 	InteractionButtonOptions,
 	InteractionCollector,
 	LinkButtonOptions,
@@ -86,8 +88,8 @@ export interface PaginatedMessageActionContext {
 	handler: PaginatedMessage;
 	author: User;
 	channel: Message['channel'];
-	response: Message;
-	collector: InteractionCollector<MessageComponentInteraction>;
+	response: Message | CommandInteraction | SelectMenuInteraction;
+	collector: InteractionCollector<Interaction>;
 }
 
 export interface PaginatedMessageOptions {

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -4,7 +4,6 @@ import type {
 	CommandInteraction,
 	ExcludeEnum,
 	Guild,
-	Interaction,
 	InteractionButtonOptions,
 	InteractionCollector,
 	LinkButtonOptions,
@@ -89,7 +88,7 @@ export interface PaginatedMessageActionContext {
 	author: User;
 	channel: Message['channel'];
 	response: Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction;
-	collector: InteractionCollector<Interaction>;
+	collector: InteractionCollector<MessageComponentInteraction>;
 }
 
 export interface PaginatedMessageOptions {

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -88,7 +88,7 @@ export interface PaginatedMessageActionContext {
 	handler: PaginatedMessage;
 	author: User;
 	channel: Message['channel'];
-	response: Message | CommandInteraction | SelectMenuInteraction;
+	response: Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction;
 	collector: InteractionCollector<Interaction>;
 }
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -1,6 +1,32 @@
 import { chunk, partition } from '@sapphire/utilities';
-import { Constants, InteractionButtonOptions, MessageActionRow, MessageButton, MessageSelectMenu, MessageSelectMenuOptions } from 'discord.js';
-import type { PaginatedMessageAction, PaginatedMessageActionButton, PaginatedMessageActionLink, PaginatedMessageActionMenu } from '.';
+import {
+	CommandInteraction,
+	Constants,
+	MessageActionRow,
+	SelectMenuInteraction,
+	type InteractionButtonOptions,
+	type Message,
+	type MessageButton,
+	type MessageSelectMenu,
+	type MessageSelectMenuOptions
+} from 'discord.js';
+import type {
+	PaginatedMessageAction,
+	PaginatedMessageActionButton,
+	PaginatedMessageActionLink,
+	PaginatedMessageActionMenu
+} from './PaginatedMessageTypes';
+
+/**
+ * Checks whether the PaginatedMessage runs on an {@link CommandInteraction}, {@link SelectMenuInteraction} or {@link Message}
+ * @param messageOrInteraction The message or interaction that the PaginatedMessage runs on
+ * @returns `true` if the PaginatedMessage runs on an an {@link CommandInteraction} or {@link SelectMenuInteraction}, `false` if it runs on a {@link Message}
+ */
+export function runsOnInteraction(
+	messageOrInteraction: Message | CommandInteraction | SelectMenuInteraction
+): messageOrInteraction is CommandInteraction | SelectMenuInteraction {
+	return messageOrInteraction instanceof CommandInteraction || messageOrInteraction instanceof SelectMenuInteraction;
+}
 
 export function actionIsButtonOrMenu(action: PaginatedMessageAction): action is PaginatedMessageActionButton | PaginatedMessageActionMenu {
 	return (

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -1,14 +1,15 @@
 import { chunk, partition } from '@sapphire/utilities';
 import {
-	CommandInteraction,
 	Constants,
+	Message,
 	MessageActionRow,
-	SelectMenuInteraction,
+	type ButtonInteraction,
+	type CommandInteraction,
 	type InteractionButtonOptions,
-	type Message,
 	type MessageButton,
 	type MessageSelectMenu,
-	type MessageSelectMenuOptions
+	type MessageSelectMenuOptions,
+	type SelectMenuInteraction
 } from 'discord.js';
 import type {
 	PaginatedMessageAction,
@@ -23,9 +24,9 @@ import type {
  * @returns `true` if the PaginatedMessage runs on an an {@link CommandInteraction} or {@link SelectMenuInteraction}, `false` if it runs on a {@link Message}
  */
 export function runsOnInteraction(
-	messageOrInteraction: Message | CommandInteraction | SelectMenuInteraction
-): messageOrInteraction is CommandInteraction | SelectMenuInteraction {
-	return messageOrInteraction instanceof CommandInteraction || messageOrInteraction instanceof SelectMenuInteraction;
+	messageOrInteraction: Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction
+): messageOrInteraction is CommandInteraction | SelectMenuInteraction | ButtonInteraction {
+	return !(messageOrInteraction instanceof Message);
 }
 
 export function actionIsButtonOrMenu(action: PaginatedMessageAction): action is PaginatedMessageActionButton | PaginatedMessageActionMenu {


### PR DESCRIPTION
Tested:
- [x] A deferred CommandInteraction
- [x] A deferred SelectMenu interaction
- [x] A **not** deferred Command interaction
- [x] A **not** deferred SelectMenu interaction
- [x] A **not** deferred Button interaction
- [x] Message based commands

Only didn't *really* check previously replied to interactions but the PaginatedMessage itself gets `.replied` set to true after 1 ButtonInteraction which I did test so that comes down to the same thing.
