### PR TITLE
fix(PaginatedMessage): fix footer application when there are multiple embeds

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1015,7 +1015,9 @@ export class PaginatedMessage {
 			return message;
 		}
 
-		for (const [idx, embed] of Object.entries(message.embeds)) {
+		const embedsWithFooterApplied = deepClone(message.embeds);
+
+		for (const [idx, embed] of Object.entries(embedsWithFooterApplied)) {
 			if (embed) {
 				embed.footer ??= { text: this.template.embeds?.[Number(idx)]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
 				embed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
@@ -1024,7 +1026,7 @@ export class PaginatedMessage {
 			}
 		}
 
-		return message;
+		return { ...message, embeds: embedsWithFooterApplied };
 	}
 
 	private applyTemplate(


### PR DESCRIPTION
I honestly don't even really get it but it does solve the issue. For some reason with the following code, the pagination footer was applied incorrectly

**Code:**
```ts
import { PaginatedMessage } from '@sapphire/discord.js-utilities';
import { Command } from '@sapphire/framework';
import { Message, MessageEmbed } from 'discord.js';

const myMessage = new PaginatedMessage({
  template: new MessageEmbed().setColor('#FF0000').setFooter({
    text: ' Official Bot from server'
  })
});

export class UserCommand extends Command {
  public override async messageRun(msg: Message) {
    await msg.channel.sendTyping();

    myMessage
      .addPageEmbeds((embed1, embed2, embed3) => {
        // You can add up to 10 embeds
        embed1.setColor('#FF0000').setDescription('example description 1');

        embed2.setColor('#00FF00').setDescription('example description 2');

        embed3.setColor('#0000FF').setDescription('example description 3');

        return [embed1, embed2, embed3];
      })
      .addPageEmbeds((embed1, embed2, embed3) => {
        // You can add up to 10 embeds
        embed1.setColor('#FF0000').setDescription('example description 1');

        embed2.setColor('#00FF00').setDescription('example description 2');

        embed3.setColor('#0000FF').setDescription('example description 3');

        return [embed1, embed2, embed3];
      });

    await myMessage.run(msg);
  }
}
```
**Result:**

![](https://favna.s-ul.eu/8NnETmIJ.png)

WTF? Why is the footer there multiple times? Well, I added some breakpoints and ended up at the `applyFooter` method. I let the `for` loop run its course and suddenly when it got to the second embed of `message.embeds` the footer in there was already updated from when it did the `for` process for the first embed of `message.embeds`?? Extremely bizarre and I have no idea why that is happening, but simply deep cloning `message.embeds` then re-applying it afterwards with object spread solves the issue.


**Result after changes (yarn linked locally)**
![image](https://user-images.githubusercontent.com/4019718/152686554-c1a827a1-301b-4345-b281-cf57968a550e.png)


---

Alternative code with which this issue can be repro'd is in my test bot code: https://github.com/Favna/musical-giggle/blob/main/src/commands/General/paginated-message.ts. I guess I never really saw it there before because it's really easy to repro.