### PR TITLE
feat(PaginatedMessage): support context menu interactions

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -11,6 +11,7 @@ import {
 	type ButtonInteraction,
 	type Collection,
 	type CommandInteraction,
+	type ContextMenuInteraction,
 	type Message,
 	type MessageComponentInteraction,
 	type MessageOptions,
@@ -116,7 +117,7 @@ export class PaginatedMessage {
 	/**
 	 * The response message used to edit on page changes.
 	 */
-	public response: APIMessage | Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction | null = null;
+	public response: APIMessage | Message | CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction | null = null;
 
 	/**
 	 * The collector used for handling component interactions.
@@ -741,14 +742,17 @@ export class PaginatedMessage {
 	 *
 	 * @param messageOrInteraction The message or interaction that triggered this {@link PaginatedMessage}.
 	 * Generally this will be the command message or an interaction
-	 * (either a {@link CommandInteraction}, a {@link SelectMenuInteraction} or a {@link ButtonInteraction}),
+	 * (either a {@link CommandInteraction}, a {@link ContextMenuInteraction}, a {@link SelectMenuInteraction} or a {@link ButtonInteraction}),
 	 * but it can also be another message from your client, i.e. to indicate a loading state.
 	 *
 	 * @param target The user who will be able to interact with the buttons of this {@link PaginatedMessage}.
 	 * If `messageOrInteraction` is an instance of {@link Message} then this defaults to {@link Message.author messageOrInteraction.author},
 	 * and if it is an instance of {@link CommandInteraction} then it defaults to {@link CommandInteraction.user messageOrInteraction.user}.
 	 */
-	public async run(messageOrInteraction: Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction, target?: User): Promise<this> {
+	public async run(
+		messageOrInteraction: Message | CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction,
+		target?: User
+	): Promise<this> {
 		// Only execute if there is a channel to send the reply to
 		if (messageOrInteraction.channel) {
 			// Assign the target based on whether a Message or CommandInteraction was passed in
@@ -837,13 +841,13 @@ export class PaginatedMessage {
 	 *
 	 * @param messageOrInteraction The message or interaction that triggered this {@link PaginatedMessage}.
 	 * Generally this will be the command message or an interaction
-	 * (either a {@link CommandInteraction}, a {@link SelectMenuInteraction} or a {@link ButtonInteraction}),
+	 * (either a {@link CommandInteraction}, a {@link ContextMenuInteraction}, a {@link SelectMenuInteraction} or a {@link ButtonInteraction}),
 	 * but it can also be another message from your client, i.e. to indicate a loading state.
 	 *
 	 * @param author The author the handler is for.
 	 */
 	protected async setUpMessage(
-		messageOrInteraction: Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction,
+		messageOrInteraction: Message | CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction,
 		targetUser: User
 	): Promise<void> {
 		// Get the current page

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -6,6 +6,7 @@ import {
 	MessageActionRow,
 	type ButtonInteraction,
 	type CommandInteraction,
+	type ContextMenuInteraction,
 	type InteractionButtonOptions,
 	type MessageButton,
 	type MessageSelectMenu,
@@ -20,13 +21,13 @@ import type {
 } from './PaginatedMessageTypes';
 
 /**
- * Checks whether the PaginatedMessage runs on an {@link CommandInteraction}, {@link SelectMenuInteraction} or {@link Message}
+ * Checks whether the PaginatedMessage runs on an {@link CommandInteraction}, {@link ContextMenuInteraction}, {@link SelectMenuInteraction} or {@link Message}
  * @param messageOrInteraction The message or interaction that the PaginatedMessage runs on
- * @returns `true` if the PaginatedMessage runs on an an {@link CommandInteraction} or {@link SelectMenuInteraction}, `false` if it runs on a {@link Message}
+ * @returns `true` if the PaginatedMessage runs on an an {@link CommandInteraction}, {@link ContextMenuInteraction} or {@link SelectMenuInteraction}, `false` if it runs on a {@link Message}
  */
 export function runsOnInteraction(
-	messageOrInteraction: APIMessage | Message | CommandInteraction | SelectMenuInteraction | ButtonInteraction
-): messageOrInteraction is CommandInteraction | SelectMenuInteraction | ButtonInteraction {
+	messageOrInteraction: APIMessage | Message | CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction
+): messageOrInteraction is CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction {
 	return !(messageOrInteraction instanceof Message);
 }
 


### PR DESCRIPTION
This PR adds support for [Context Menu Interactions](https://discord.js.org/#/docs/discord.js/stable/class/ContextMenuInteraction) to be passed in for paginated messages.