### PR TITLE
feat(PaginatedMessage): emit warning when running in a DM channel without required client options

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -808,7 +808,7 @@ export class PaginatedMessage {
 			) {
 				process.emitWarning(
 					[
-						'PaginatedMessage initiated in a DM channel without the client having required partial configured.',
+						'PaginatedMessage was initiated in a DM channel without the client having the required partial configured.',
 						'If you want PaginatedMessage to work in DM channels then make sure you start your client with "CHANNEL" added to "client.options.partials".',
 						'If you do not want to be alerted about this in the future then you can disable this warning by setting "PaginatedMessage.emitPartialDMChannelWarning" to "false", or use "setEmitPartialDMChannelWarning(false)" before calling "run".'
 					].join('\n'),

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -3,17 +3,22 @@ import type { APIMessage } from 'discord-api-types/v9';
 import type {
 	ButtonInteraction,
 	CommandInteraction,
+	ContextMenuInteraction,
 	ExcludeEnum,
 	Guild,
 	InteractionButtonOptions,
 	InteractionCollector,
+	InteractionReplyOptions,
+	InteractionUpdateOptions,
 	LinkButtonOptions,
 	Message,
 	MessageComponentInteraction,
+	MessageEditOptions,
 	MessageEmbed,
 	MessageOptions,
 	MessageSelectMenuOptions,
 	MessageSelectOptionData,
+	ReplyMessageOptions,
 	SelectMenuInteraction,
 	StageChannel,
 	StoreChannel,
@@ -175,4 +180,13 @@ export interface PaginatedMessageInternationalizationContext {
 	guild: Guild | null;
 	channel: Message['channel'] | StoreChannel | StageChannel | VoiceChannel | null;
 	author: User | null;
+}
+
+export interface SafeReplyToInteractionParameters<T extends 'edit' | 'reply' | never = never> {
+	messageOrInteraction: APIMessage | Message | CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction;
+	interactionEditReplyContent: WebhookEditMessageOptions;
+	interactionReplyContent: InteractionReplyOptions;
+	componentUpdateContent: InteractionUpdateOptions;
+	messageMethod?: T;
+	messageMethodContent?: T extends 'reply' ? ReplyMessageOptions : MessageEditOptions;
 }


### PR DESCRIPTION
This introduces a new potential emitted warning when the client is not
properly configured to handle DM commands.

Whether the warning is emitted at all can be configured so people can choose to not get it at all.
It will also only be emitted once per instance of PaginatedMessage.

On the note of the warning being per instance of PaginatedMessage, yes that does often mean that
people will get it for every time that `run` is called because it's common (and recommended)
to call `new PaginatedMessage` inside of the `*Run` method.
I don't think it's fitting to keep track of that boolean outside of the class though.

Calling run twice example:
![](https://favna.s-ul.eu/SOJzv2G9.png)
