### PR TITLE
feat(discord-utilities): Add token regex

### DIFF
--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -120,7 +120,7 @@ export const SnowflakeRegex = /^(?<id>\d{17,19})$/;
  * You can use the name of the capture group to determine if the validated token was configured for a user with Multi-Factor Authentication, for a user without Multi-Factor Authentication, or for a bot application.
  * If both capture groups are undefined, then the token is invalid.
  */
-export const TokenRegex = /(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<botToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i;
+export const TokenRegex = /(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<basicToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i;
 
 /**
  * Regex that can capture a Twemoji (Twitter Emoji)

--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -117,6 +117,11 @@ export const SnowflakeRegex = /^(?<id>\d{17,19})$/;
 export const TwemojiRegex = twemojiRegex;
 
 /**
+ * Regex that can capture a Discord Token
+ */
+export const TokenRegex = /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
+
+/**
  * Regex that can capture the ID of a user in Discord user mentions
  * @raw `/^<@!?(?<id>\d{17,19})>$/`
  * @remark Capture group 1 is the ID of the user. It is named `id`.

--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -111,15 +111,16 @@ export const RoleMentionRegex = /^<@&(?<id>\d{17,19})>$/;
 export const SnowflakeRegex = /^(?<id>\d{17,19})$/;
 
 /**
+ * Regex that can capture a Discord Token
+ * @raw /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
+ */
+export const TokenRegex = /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
+
+/**
  * Regex that can capture a Twemoji (Twitter Emoji)
  * @raw {@linkplain https://github.com/twitter/twemoji-parser/blob/master/src/lib/regex.js See official source code}
  */
 export const TwemojiRegex = twemojiRegex;
-
-/**
- * Regex that can capture a Discord Token
- */
-export const TokenRegex = /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
 
 /**
  * Regex that can capture the ID of a user in Discord user mentions

--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -114,7 +114,7 @@ export const SnowflakeRegex = /^(?<id>\d{17,19})$/;
  * Regex that can capture a Discord Token
  * @raw /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
  */
-export const TokenRegex = /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
+export const TokenRegex = /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i;
 
 /**
  * Regex that can capture a Twemoji (Twitter Emoji)

--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -112,9 +112,20 @@ export const SnowflakeRegex = /^(?<id>\d{17,19})$/;
 
 /**
  * Regex that can capture a Discord Token
- * @raw /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i
+ *
+ * @raw `/(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<botToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i`
+ *
+ * @remark Capture group 1 can be used to retrieve a token for a User that has Multi-Factor Authentication enabled. It is named `mfaToken`.
+ *
+ * @remark Capture group 2 can be used to retrieve a token for a Bot application. It is named `botToken`.
+ *
+ * @remark For a valid token, either Capture group 1 or Capture group 2 will always be undefined, whereas the other group will then be defined and
+ * contain the matched token.
+ * You can use the name of the capture group to determine if the validated token was configured for a user with Multi-Factor Authentication, or for a
+ * bot application.
+ * If both capture groups are undefined, then the token is invalid.
  */
-export const TokenRegex = /(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i;
+export const TokenRegex = /(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<botToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i;
 
 /**
  * Regex that can capture a Twemoji (Twitter Emoji)

--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -112,17 +112,12 @@ export const SnowflakeRegex = /^(?<id>\d{17,19})$/;
 
 /**
  * Regex that can capture a Discord Token
- *
- * @raw `/(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<botToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i`
- *
+ * @raw `/(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<basicToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i`
  * @remark Capture group 1 can be used to retrieve a token for a User that has Multi-Factor Authentication enabled. It is named `mfaToken`.
- *
- * @remark Capture group 2 can be used to retrieve a token for a Bot application. It is named `botToken`.
- *
+ * @remark Capture group 2 can be used to retrieve a token for a User that doesn't have Multi-Factor Authentication enabled, or a Bot application. It is named `basicToken`.
  * @remark For a valid token, either Capture group 1 or Capture group 2 will always be undefined, whereas the other group will then be defined and
  * contain the matched token.
- * You can use the name of the capture group to determine if the validated token was configured for a user with Multi-Factor Authentication, or for a
- * bot application.
+ * You can use the name of the capture group to determine if the validated token was configured for a user with Multi-Factor Authentication, for a user without Multi-Factor Authentication, or for a bot application.
  * If both capture groups are undefined, then the token is invalid.
  */
 export const TokenRegex = /(?<mfaToken>mfa\.[a-z0-9_-]{20,})|(?<botToken>[a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/i;


### PR DESCRIPTION
A token regex can be useful for automatically resetting tokens, and validating tokens before making requests or connecting to the gateway.

Source is from searching TOKEN_REGEX in https://canary.discord.com/assets/2fa49c2711296797d83c.js

![image](https://user-images.githubusercontent.com/68407783/155856623-de9325a7-e339-4d14-9275-d1b1a4348d79.png)
