### PR TITLE
fix(discord-utilities) update webhook regex

### DIFF
--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -150,4 +150,4 @@ export const WebSocketUrlRegex = /^wss?:\/\//;
  * @remark Capture group 3 is the token of the Discord Webhook. It is named `token`.
  * @remark for regular HTTP URLs see {@link HttpUrlRegex}
  */
-export const WebhookRegex = /(?<url>^https:\/\/(?:(?:canary|ptb).)?discordapp.com\/api\/webhooks\/(?<id>\d+)\/(?<token>[\w-]+)\/?$)/;
+export const WebhookRegex = /(?<url>^https:\/\/(?:(?:canary|ptb).)?discord(app)?.com\/api(\/v\d+)?\/webhooks\/(?<id>\d+)\/(?<token>[\w-]+)\/?$)/;

--- a/packages/discord-utilities/src/lib/regexes.ts
+++ b/packages/discord-utilities/src/lib/regexes.ts
@@ -150,4 +150,4 @@ export const WebSocketUrlRegex = /^wss?:\/\//;
  * @remark Capture group 3 is the token of the Discord Webhook. It is named `token`.
  * @remark for regular HTTP URLs see {@link HttpUrlRegex}
  */
-export const WebhookRegex = /(?<url>^https:\/\/(?:(?:canary|ptb).)?discord(app)?.com\/api(\/v\d+)?\/webhooks\/(?<id>\d+)\/(?<token>[\w-]+)\/?$)/;
+export const WebhookRegex = /(?<url>^https:\/\/(?:(?:canary|ptb).)?discord(?:app)?.com\/api(?:\/v\d+)?\/webhooks\/(?<id>\d+)\/(?<token>[\w-]+)\/?$)/;


### PR DESCRIPTION
Its been discord.com for a while, and this regex does not work for current webhooks
Also made it match API versions since those work too

![image](https://commandtechno.com/i/77pnnhu4dd8x)