### PR TITLE
feat(utlities): add title case `options` param

### DIFF
--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -36,6 +36,6 @@ export * from './lib/range';
 export * from './lib/regExpEsc';
 export * from './lib/roundNumber';
 export * from './lib/splitText';
-export { toTitleCase } from './lib/toTitleCase';
+export { toTitleCase, ToTitleCaseOptions } from './lib/toTitleCase';
 export * from './lib/tryParse';
 export * from './lib/utilityTypes';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -36,6 +36,6 @@ export * from './lib/range';
 export * from './lib/regExpEsc';
 export * from './lib/roundNumber';
 export * from './lib/splitText';
-export * from './lib/toTitleCase';
+export { toTitleCase } from './lib/toTitleCase';
 export * from './lib/tryParse';
 export * from './lib/utilityTypes';

--- a/packages/utilities/src/lib/toTitleCase.ts
+++ b/packages/utilities/src/lib/toTitleCase.ts
@@ -10,6 +10,8 @@ const baseVariants: Record<string, string> = {
  * Converts a string to Title Case
  * @description This is designed to also ensure common Discord PascalCased strings
  * 				are put in their TitleCase baseVariants. See below for the full list.
+ *              You can also provide your own variants to merge with the baseVariants
+ *              for your own functionality use.
  * @param str The string to title case
  * @param variants The optional title case variants to merge with baseVariants
  * @terms

--- a/packages/utilities/src/lib/toTitleCase.ts
+++ b/packages/utilities/src/lib/toTitleCase.ts
@@ -1,5 +1,18 @@
 const TO_TITLE_CASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
-const baseVariants: Record<string, string> = {
+
+/**
+ * The variants that will not strictly follow the `toTitleCase` algorithm and will instead return the value matched with the key.
+ *
+ * This table lists how certain terms are converted, these are case insensitive.
+ * Any terms not included are converted to regular `Titlecase`.
+ * |       Term      	|   Converted To  	|
+ * |:---------------:	|:---------------:	|
+ * | textchannel     	| TextChannel     	|
+ * | voicechannel    	| VoiceChannel    	|
+ * | categorychannel 	| CategoryChannel 	|
+ * | guildmember     	| GuildMember     	|
+ */
+export const baseVariants: Record<string, string> = {
 	textchannel: 'TextChannel',
 	voicechannel: 'VoiceChannel',
 	categorychannel: 'CategoryChannel',
@@ -8,25 +21,18 @@ const baseVariants: Record<string, string> = {
 
 /**
  * Converts a string to Title Case
- * @description This is designed to also ensure common Discord PascalCased strings
- * 				are put in their TitleCase baseVariants. See below for the full list.
- *              You can also provide your own variants to merge with the baseVariants
- *              for your own functionality use.
- * @param str The string to title case
- * @param variants The optional title case variants to merge with baseVariants
- * @terms
- * This table lists how certain terms are converted, these are case insensitive.
- * Any terms not included are converted to regular Titlecase.
  *
- *      | Term            |    Converted To |
- *      |-----------------|-----------------|
- *      | textchannel     |     TextChannel |
- *      | voicechannel    |    VoiceChannel |
- *      | categorychannel | CategoryChannel |
- *      | guildmember     |     GuildMember |
+ * @description This is designed to also ensure common Discord PascalCased strings
+ * are put in their TitleCase {@link baseVariants}.
+ *
+ * You can also provide your own variants to merge with the {@link baseVariants} for
+ * your own functionality use.
+ *
+ * @param str The string to title case
+ * @param additionalVariants The optional title case variants to merge with {@link baseVariants}
  */
-export function toTitleCase(str: string, variants: Record<string, string> = {}): string {
-	const titleCaseVariants = { ...baseVariants, ...variants };
+export function toTitleCase(str: string, additionalVariants: Record<string, string> = {}): string {
+	const titleCaseVariants = { ...baseVariants, ...additionalVariants };
 
 	return str.replace(TO_TITLE_CASE, (txt) => titleCaseVariants[txt] ?? txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase());
 }

--- a/packages/utilities/src/lib/toTitleCase.ts
+++ b/packages/utilities/src/lib/toTitleCase.ts
@@ -1,6 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const TOTITLECASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
-const titleCaseVariants: Record<string, string> = {
+const TO_TITLE_CASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
+const baseVariants: Record<string, string> = {
 	textchannel: 'TextChannel',
 	voicechannel: 'VoiceChannel',
 	categorychannel: 'CategoryChannel',
@@ -10,8 +9,9 @@ const titleCaseVariants: Record<string, string> = {
 /**
  * Converts a string to Title Case
  * @description This is designed to also ensure common Discord PascalCased strings
- * 				are put in their TitleCase titleCaseVariants. See below for the full list.
+ * 				are put in their TitleCase baseVariants. See below for the full list.
  * @param str The string to title case
+ * @param variants The optional title case variants to merge with baseVariants
  * @terms
  * This table lists how certain terms are converted, these are case insensitive.
  * Any terms not included are converted to regular Titlecase.
@@ -23,6 +23,8 @@ const titleCaseVariants: Record<string, string> = {
  *      | categorychannel | CategoryChannel |
  *      | guildmember     |     GuildMember |
  */
-export function toTitleCase(str: string): string {
-	return str.replace(TOTITLECASE, (txt) => titleCaseVariants[txt] || txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+export function toTitleCase(str: string, variants: Record<string, string> = {}): string {
+	const titleCaseVariants = { ...baseVariants, ...variants };
+
+	return str.replace(TO_TITLE_CASE, (txt) => titleCaseVariants[txt] ?? txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase());
 }

--- a/packages/utilities/src/lib/toTitleCase.ts
+++ b/packages/utilities/src/lib/toTitleCase.ts
@@ -4,7 +4,7 @@ const TO_TITLE_CASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
  * The variants that will not strictly follow the `toTitleCase` algorithm
  * and will instead return the value matched with the key.
  *
- * This table lists how certain terms are converted, these are case insensitive.
+ * This table lists how certain terms are converted.
  * Any terms not included are converted to regular `Titlecase`.
  * |       Term       |   Converted To   |
  * |:---------------- |:---------------- |
@@ -30,10 +30,37 @@ export const baseVariants: Record<string, string> = {
  * your own functionality use.
  *
  * @param str The string to title case
- * @param additionalVariants The optional title case variants to merge with {@link baseVariants}
+ * @param options The options to use when converting the string
  */
-export function toTitleCase(str: string, additionalVariants: Record<string, string> = {}): string {
-	const titleCaseVariants = { ...baseVariants, ...additionalVariants };
+export function toTitleCase(str: string, options: ToTitleCaseOptions = {}): string {
+	const { additionalVariants = {}, caseSensitive } = options;
+	const titleCaseVariants = {
+		...baseVariants,
+		...(caseSensitive
+			? additionalVariants
+			: Object.entries(additionalVariants).reduce<Record<string, string>>(
+					(variants, [key, variant]) => ({ ...variants, [key.toLowerCase()]: variant }),
+					{}
+			  ))
+	};
 
-	return str.replace(TO_TITLE_CASE, (txt) => titleCaseVariants[txt] ?? txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase());
+	return str.replace(
+		TO_TITLE_CASE,
+		(txt) => titleCaseVariants[caseSensitive ? txt : txt.toLowerCase()] ?? txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase()
+	);
+}
+
+/**
+ * The options to use when converting a string to title case
+ */
+export interface ToTitleCaseOptions {
+	/**
+	 * The optional additional variants to use when converting the string
+	 */
+	additionalVariants?: Record<string, string>;
+
+	/**
+	 * Whether to convert the string to title case in a case sensitive manner.
+	 */
+	caseSensitive?: boolean;
 }

--- a/packages/utilities/src/lib/toTitleCase.ts
+++ b/packages/utilities/src/lib/toTitleCase.ts
@@ -5,12 +5,12 @@ const TO_TITLE_CASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
  *
  * This table lists how certain terms are converted, these are case insensitive.
  * Any terms not included are converted to regular `Titlecase`.
- * |       Term      	|   Converted To  	|
- * |:---------------:	|:---------------:	|
- * | textchannel     	| TextChannel     	|
- * | voicechannel    	| VoiceChannel    	|
- * | categorychannel 	| CategoryChannel 	|
- * | guildmember     	| GuildMember     	|
+ * |       Term       |   Converted To   |
+ * |:---------------- |:---------------- |
+ * | textchannel      | TextChannel      |
+ * | voicechannel     | VoiceChannel     |
+ * | categorychannel  | CategoryChannel  |
+ * | guildmember      | GuildMember      |
  */
 export const baseVariants: Record<string, string> = {
 	textchannel: 'TextChannel',

--- a/packages/utilities/src/lib/toTitleCase.ts
+++ b/packages/utilities/src/lib/toTitleCase.ts
@@ -1,7 +1,8 @@
 const TO_TITLE_CASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
 
 /**
- * The variants that will not strictly follow the `toTitleCase` algorithm and will instead return the value matched with the key.
+ * The variants that will not strictly follow the `toTitleCase` algorithm
+ * and will instead return the value matched with the key.
  *
  * This table lists how certain terms are converted, these are case insensitive.
  * Any terms not included are converted to regular `Titlecase`.

--- a/packages/utilities/tests/toTitleCase.test.ts
+++ b/packages/utilities/tests/toTitleCase.test.ts
@@ -20,14 +20,26 @@ describe('toTitleCase', () => {
 	});
 
 	test('GIVEN variant THEN returns expected', () => {
-		const source = toTitleCase('somethingspecial', { somethingspecial: 'SomethingSpecial' });
+		const source = toTitleCase('somethingspecial', { additionalVariants: { somethingspecial: 'SomethingSpecial' } });
 		const expected = 'SomethingSpecial';
 		expect(source).toBe(expected);
 	});
 
 	test('GIVEN keyword WITH variant THEN returns expected', () => {
-		const source = toTitleCase('textchannel', { somethingspecial: 'SomethingSpecial' });
+		const source = toTitleCase('textchannel', { additionalVariants: { somethingspecial: 'SomethingSpecial' } });
 		const expected = 'TextChannel';
+		expect(source).toBe(expected);
+	});
+
+	test('GIVEN keyword WITH caseSensitive THEN returns expected', () => {
+		const source = toTitleCase('textChannel', { caseSensitive: true });
+		const expected = 'Textchannel';
+		expect(source).toBe(expected);
+	});
+
+	test('GIVEN variant WITH caseSensitive THEN returns expected', () => {
+		const source = toTitleCase('somethingSpecial', { additionalVariants: { somethingspecial: 'SomethingSpecial' }, caseSensitive: true });
+		const expected = 'Somethingspecial';
 		expect(source).toBe(expected);
 	});
 });

--- a/packages/utilities/tests/toTitleCase.test.ts
+++ b/packages/utilities/tests/toTitleCase.test.ts
@@ -18,4 +18,16 @@ describe('toTitleCase', () => {
 		const expected = 'TextChannel';
 		expect(source).toBe(expected);
 	});
+
+	test('GIVEN variant THEN returns expected', () => {
+		const source = toTitleCase('somethingspecial', { somethingspecial: 'SomethingSpecial' });
+		const expected = 'SomethingSpecial';
+		expect(source).toBe(expected);
+	});
+
+	test('GIVEN keyword WITH variant THEN returns expected', () => {
+		const source = toTitleCase('textchannel', { somethingspecial: 'SomethingSpecial' });
+		const expected = 'TextChannel';
+		expect(source).toBe(expected);
+	});
 });


### PR DESCRIPTION
This PR adds functionality to add your own variants and case sensitivity for `toTitleCase()`

```ts
import { totTitleCase } from '@sapphire/utilities';

toTitleCase('json textchannel', { additionalVariants: { json: 'JSON' } }); // 'JSON TextChannel'
toTitleCase('jSON textChannel', { additionalVariants: { json: 'JSON' }, caseSensitive: true }; // 'Json Textchannel'
```

# Changes

- Add `options` parameter to `toTitleCase()` function along with it's functionality and tests.
- Rename `TOTITLECASE` to `TO_TITLE_CASE`
- Rename `titleCaseVariants` to `baseVariants`
- Use `String#substring()` instead of `String#substr()` as it's deprecated.

This feature should be released as semver minor.