### PR TITLE
fix(PaginatedMessage): removed duplicate page index footers on multiple embed pages

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1149,6 +1149,12 @@ export class PaginatedMessage {
 		}
 	}
 
+	/**
+     * Applies footer to the last embed of the page
+     * @param message The message options
+     * @param index The current index
+     * @returns The message options with the footer applied
+     */
 	protected applyFooter(message: PaginatedMessageMessageOptionsUnion, index: number): PaginatedMessageMessageOptionsUnion {
 		if (!message.embeds?.length) {
 			return message;
@@ -1156,14 +1162,14 @@ export class PaginatedMessage {
 
 		const embedsWithFooterApplied = deepClone(message.embeds);
 
-		for (const [idx, embed] of Object.entries(embedsWithFooterApplied)) {
-			if (embed) {
-				embed.footer ??= { text: this.template.embeds?.[Number(idx)]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
-				embed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
-					embed.footer.text ? ` ${this.embedFooterSeparator} ${embed.footer.text}` : ''
-				}`;
-			}
-		}
+        const idx = embedsWithFooterApplied.length - 1;
+        const lastEmbed = embedsWithFooterApplied[idx];
+        if (lastEmbed) {
+            lastEmbed.footer ??= { text: this.template.embeds?.[Number(idx)]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
+            lastEmbed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
+                lastEmbed.footer.text ? ` ${this.embedFooterSeparator} ${lastEmbed.footer.text}` : ''
+            }`;
+        }
 
 		return { ...message, embeds: embedsWithFooterApplied };
 	}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1165,7 +1165,7 @@ export class PaginatedMessage {
 		const idx = embedsWithFooterApplied.length - 1;
 		const lastEmbed = embedsWithFooterApplied[idx];
 		if (lastEmbed) {
-			lastEmbed.footer ??= { text: this.template.embeds?.[Number(idx)]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
+			lastEmbed.footer ??= { text: this.template.embeds?.[idx]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
 			lastEmbed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
 				lastEmbed.footer.text ? ` ${this.embedFooterSeparator} ${lastEmbed.footer.text}` : ''
 			}`;

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1150,11 +1150,11 @@ export class PaginatedMessage {
 	}
 
 	/**
-     * Applies footer to the last embed of the page
-     * @param message The message options
-     * @param index The current index
-     * @returns The message options with the footer applied
-     */
+	 * Applies footer to the last embed of the page
+	 * @param message The message options
+	 * @param index The current index
+	 * @returns The message options with the footer applied
+	 */
 	protected applyFooter(message: PaginatedMessageMessageOptionsUnion, index: number): PaginatedMessageMessageOptionsUnion {
 		if (!message.embeds?.length) {
 			return message;
@@ -1162,14 +1162,14 @@ export class PaginatedMessage {
 
 		const embedsWithFooterApplied = deepClone(message.embeds);
 
-        const idx = embedsWithFooterApplied.length - 1;
-        const lastEmbed = embedsWithFooterApplied[idx];
-        if (lastEmbed) {
-            lastEmbed.footer ??= { text: this.template.embeds?.[Number(idx)]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
-            lastEmbed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
-                lastEmbed.footer.text ? ` ${this.embedFooterSeparator} ${lastEmbed.footer.text}` : ''
-            }`;
-        }
+		const idx = embedsWithFooterApplied.length - 1;
+		const lastEmbed = embedsWithFooterApplied[idx];
+		if (lastEmbed) {
+			lastEmbed.footer ??= { text: this.template.embeds?.[Number(idx)]?.footer?.text ?? this.template.embeds?.[0]?.footer?.text ?? '' };
+			lastEmbed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
+				lastEmbed.footer.text ? ` ${this.embedFooterSeparator} ${lastEmbed.footer.text}` : ''
+			}`;
+		}
 
 		return { ...message, embeds: embedsWithFooterApplied };
 	}


### PR DESCRIPTION
**Updated the applyFooter() function so it only applies the footer to the last embed of the page.**

_This prevents the footer to be repeated multiple times on a single page, when the page has multiple embeds (added with PaginatedMessage.addPageEmbeds(), for example)._