### PR TITLE
fix(PaginatedMessage): update i18nContext to match plugin-i18next

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -6,6 +6,7 @@ import type {
 	ContextMenuInteraction,
 	ExcludeEnum,
 	Guild,
+	Interaction,
 	InteractionButtonOptions,
 	InteractionCollector,
 	InteractionReplyOptions,
@@ -177,9 +178,21 @@ export type PaginatedMessageMessageOptionsUnion = MessageOptions | WebhookEditMe
  * This context enables implementation of per-guild, per-channel, and per-user localization.
  */
 export interface PaginatedMessageInternationalizationContext {
+	/** The {@link Guild} object to fetch the preferred language for, or `null` if the language is to be fetched in a DM. */
 	guild: Guild | null;
+	/** The {@link DiscordChannel} object to fetch the preferred language for. */
 	channel: Message['channel'] | StoreChannel | StageChannel | VoiceChannel | null;
-	author: User | null;
+	/**
+	 * @deprecated Use {@link InternationalizationContext.user} instead; this will be removed in the next major version.
+	 * The user to fetch the preferred language for.
+	 */
+	author?: User | null;
+	/** The user to fetch the preferred language for. */
+	user: User | null;
+	/** The {@link Interaction.guildLocale} provided by the Discord API */
+	interactionGuildLocale?: Interaction['guildLocale'];
+	/** The {@link Interaction.locale} provided by the Discord API */
+	interactionLocale?: Interaction['locale'];
 }
 
 export interface SafeReplyToInteractionParameters<T extends 'edit' | 'reply' | never = never> {


### PR DESCRIPTION
Currently this mismatch causes a type build issue when implementing the static methods:
```ts
import { LanguageKeys } from '#lib/i18n/languageKeys';
import { PaginatedMessage } from '@sapphire/discord.js-utilities';
import { container } from '@sapphire/framework';
import i18n from 'i18next';

PaginatedMessage.selectMenuOptions = async (pageIndex, internationalizationContext) => {
	const languageForContext = await container.i18n.fetchLanguage(internationalizationContext);

	return { label: `${i18n.t(LanguageKeys.Globals.PaginatedMessagePage, { lng: languageForContext ?? 'en-US' })} ${pageIndex}` };
};
```

![image](https://user-images.githubusercontent.com/4019718/164969138-61a3dc33-1fb5-4483-a4c3-7f60c7f4c54f.png)
