### PR TITLE
fix(limits): align with ddev docs

### DIFF
--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -195,7 +195,7 @@ export const SelectMenuLimits = {
 	/**
 	 * Maximum characters allowed in a select menu placeholder.
 	 */
-	MaximumPlaceholderCharacters: 100,
+	MaximumPlaceholderCharacters: 150,
 
 	/**
 	 * Maximum "minimum" values allowed in a select menu.
@@ -303,7 +303,7 @@ export const AutoCompleteLimits = {
 	/**
 	 * Maximum options allowed in a single autocomplete response.
 	 */
-	MaximumAmountOfOptions: 20,
+	MaximumAmountOfOptions: 25,
 
 	/**
 	 * Maximum characters allowed in a select menu option's name.


### PR DESCRIPTION
This PR changes two limits to align with the ddev documentation:
- [custom placeholder text if nothing is selected, max 150 characters](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure)
- [autocomplete choices (max of 25 choices)](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete)
