### PR TITLE
refactor: change `const enum` for regular `enum`

### DIFF
--- a/packages/decorators/src/djs-decorators.ts
+++ b/packages/decorators/src/djs-decorators.ts
@@ -3,7 +3,7 @@ import { UserError } from '@sapphire/framework';
 import { Message, PermissionResolvable, Permissions } from 'discord.js';
 import { createFunctionPrecondition, FunctionFallback } from './utils';
 
-export const enum DecoratorIdentifiers {
+export enum DecoratorIdentifiers {
 	RequiresClientPermissionsGuildOnly = 'requiresClientPermissionsGuildOnly',
 	RequiresClientPermissionsMissingPermissions = 'requiresClientPermissionsMissingPermissions',
 	RequiresUserPermissionsGuildOnly = 'requiresUserPermissionsGuildOnly',

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -34,7 +34,7 @@
 
 -   Written in TypeScript
 -   Fully tested
--   Exported `const enum` for the common return data types.
+-   Exported `enum` for the common return data types.
 -   Throws distinctive errors when the API returns a "not ok" status code to make them easier to understand.
 -   Enforces casting the return type when requesting JSON data, to ensure your return data is strictly typed.
 -   Uses [cross-fetch] so this package can be used in NodeJS (where it uses [node-fetch]) and browser (where it uses [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API))

--- a/packages/fetch/src/lib/types.ts
+++ b/packages/fetch/src/lib/types.ts
@@ -1,7 +1,7 @@
 /**
  * The supported return types for the `fetch` method
  */
-export const enum FetchResultTypes {
+export enum FetchResultTypes {
 	/**
 	 * Returns only the body, as JSON. Similar to [`Body.json()`](https://developer.mozilla.org/en-US/docs/Web/API/Body/json).
 	 *
@@ -33,7 +33,7 @@ export const enum FetchResultTypes {
 /**
  * The list of [HTTP Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)
  */
-export const enum FetchMethods {
+export enum FetchMethods {
 	/**
 	 * The `GET` method requests a representation of the specified resource. Requests using `GET` should only retrieve data.
 	 * @see [MDN / Web / HTTP / Methods / GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET)
@@ -86,7 +86,7 @@ export const enum FetchMethods {
  * Media Content Types are also known as a Multipurpose Internet Mail Extensions or MIME type
  * Media Content Types are defined and standardized in IETF's [RFC 6838](https://datatracker.ietf.org/doc/html/rfc6838).
  */
-export const enum FetchMediaContentTypes {
+export enum FetchMediaContentTypes {
 	/**
 	 * The `audio/aac` media content type.
 	 * @see [Media-Types / audio / aac](https://www.iana.org/assignments/media-types/audio/aac)

--- a/packages/fetch/tests/fetch.test.ts
+++ b/packages/fetch/tests/fetch.test.ts
@@ -185,7 +185,6 @@ describe('fetch', () => {
 
 describe('FetchMediaContentTypes', () => {
 	test('GIVEN Entries of FetchMediaContentTypes THEN returns expected entries', () => {
-		// @ts-expect-error TypeScript doesn't like this on const enum but because we have `--preserveConstEnums` it is actually possible
 		const MediaTypeEntries = [...Object.entries(FetchMediaContentTypes)];
 
 		expect(MediaTypeEntries).toHaveLength(31);

--- a/packages/time-utilities/src/lib/constants.ts
+++ b/packages/time-utilities/src/lib/constants.ts
@@ -4,7 +4,7 @@ import type { DurationFormatAssetsTime, DurationFormatSeparators } from './Durat
 /**
  * The supported time types
  */
-export const enum TimeTypes {
+export enum TimeTypes {
 	Second = 'second',
 	Minute = 'minute',
 	Hour = 'hour',
@@ -14,7 +14,7 @@ export const enum TimeTypes {
 	Year = 'year'
 }
 
-export const enum Time {
+export enum Time {
 	Millisecond = 1,
 	Second = 1000,
 	Minute = 1000 * 60,


### PR DESCRIPTION
To be frank I don't know why exactly but @vladfrangu told Kyra to remove it for lexure here https://github.com/sapphiredev/utilities/pull/388/files#r917235502 so I assume the others should go also
