### PR TITLE
feat(result): export `ok`, `err`, `some`, `none`, and improve docs

### DIFF
--- a/packages/result/README.md
+++ b/packages/result/README.md
@@ -4,7 +4,7 @@
 
 # @sapphire/result
 
-**Result wrappers for function try-catch code blocks**
+**A TypeScript port of Nightly Rust's Result and Option structs**
 
 [![GitHub](https://img.shields.io/github/license/sapphiredev/utilities)](https://github.com/sapphiredev/utilities/blob/main/LICENSE.md)
 [![codecov](https://codecov.io/gh/sapphiredev/utilities/branch/main/graph/badge.svg?token=OEGIV6RFDO)](https://codecov.io/gh/sapphiredev/utilities)
@@ -15,15 +15,14 @@
 
 ## Description
 
-When having many `try-catch` blocks after one another, or multiple `try-catch` blocks nested in one another then code can become very chaotic very quickly. To alleviate that issue we have made the `@sapphire/result` which offers simple wrappers around such code. This code has been branched off of `@sapphire/framework` into its own package after we saw great success with the code there. Furthermore we also have wrappers for other arbitrary values in `isMaybe`, `isSome`, and `isNone`.
-
-The code in this package has been greatly inspired by [lexure] from [1Computer1].
+When having many `try-catch` blocks after one another, or multiple `try-catch` blocks nested in one another then code can become very chaotic very quickly. To alleviate that issue we have made the `@sapphire/result` which offers two structures based on Rust's [`Result<T, E>`](https://doc.rust-lang.org/std/result/index.html) and [`Option<T>`](https://doc.rust-lang.org/std/option/enum.Option.html) with full Nightly coverage and extra convenience methods. This code has been branched off of `@sapphire/framework` into its own package after we saw great success with the code there.
 
 ## Features
 
 -   Written in TypeScript
 -   Bundled with esbuild so it can be used in NodeJS and browsers
 -   Offers CommonJS, ESM and UMD bundles
+-   Full feature parity with Nightly Rust's `Result<T, E>` and `Option<T>`
 -   Fully tested
 
 ## Installation
@@ -36,11 +35,11 @@ npm install @sapphire/result
 
 ## Usage
 
-**Note:** While this section uses `require`, the imports match 1:1 with ESM imports. For example `const { from } = require('@sapphire/result')` equals `import { from } from '@sapphire/result'`.
+**Note:** While this section uses `require`, the imports match 1:1 with ESM imports. For example `const { Result } = require('@sapphire/result')` equals `import { Result } from '@sapphire/result'`.
 
 ### Wrapping synchronous `try-catch` blocks
 
-**Old code without `from`:**
+**Old code without `Result.from`:**
 
 ```typescript
 try {
@@ -48,28 +47,28 @@ try {
 
 	return returnCode;
 } catch (error) {
-	// Handle the error, for example let it bubble up:
-	throw new Error(error);
+	// Handle the error:
+	console.error(error);
+	return null;
 }
 ```
 
-**New Code with `from`:**
+**New Code with `Result.from`:**
 
 ```typescript
-const { from, isErr } = require('@sapphire/result');
+const { Result } = require('@sapphire/result');
 
-const returnCode = from(() => someFunctionThatMightThrow());
+const returnCode = Result.from(() => someFunctionThatMightThrow());
 
-if (isErr(returnCode)) {
-	throw new Error(returnCode.error);
-}
-
-return returnCode.value;
+return returnCode.unwrapOrElse((error) => {
+	console.error(error);
+	return null;
+});
 ```
 
 ### Wrapping asynchronous `try-catch` blocks
 
-**Old code without `fromAsync`:**
+**Old code without `Result.fromAsync`:**
 
 ```typescript
 try {
@@ -77,23 +76,23 @@ try {
 
 	return returnCode;
 } catch (error) {
-	// Handle the error, for example let it bubble up:
-	throw new Error(error);
+	// Handle the error:
+	console.error(error);
+	return null;
 }
 ```
 
-**New Code with `fromAsync`:**
+**New Code with `Result.fromAsync`:**
 
 ```typescript
-const { fromAsync, isErr } = require('@sapphire/result');
+const { Result } = require('@sapphire/result');
 
-const returnCode = await fromAsync(async () => someFunctionThatReturnsAPromiseAndMightReject());
+const returnCode = await Result.fromAsync(async () => someFunctionThatReturnsAPromiseAndMightReject());
 
-if (isErr(returnCode)) {
-	throw new Error(returnCode.error);
-}
-
-return returnCode.value;
+return returnCode.unwrapOrElse((error) => {
+	console.error(error);
+	return null;
+});
 ```
 
 ---

--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@sapphire/result",
 	"version": "2.1.1",
-	"description": "Sapphire results package",
+	"description": "A TypeScript port of Nightly Rust's Result and Option structs",
 	"author": "@sapphire",
 	"license": "MIT",
 	"main": "dist/index.js",

--- a/packages/result/src/lib/Option.ts
+++ b/packages/result/src/lib/Option.ts
@@ -4,6 +4,7 @@ import { Some, some as _some } from './Option/Some';
 
 export * from './Option/IOption';
 export * from './Option/OptionError';
+export { _some as some, _none as none };
 
 /**
  * The union of the two variations of `Option`.

--- a/packages/result/src/lib/Result.ts
+++ b/packages/result/src/lib/Result.ts
@@ -4,6 +4,7 @@ import { Ok, ok as _ok } from './Result/Ok';
 
 export * from './Result/IResult';
 export * from './Result/ResultError';
+export { _ok as ok, _err as err };
 
 /**
  * The union of the two variations of `Result`.

--- a/packages/result/tests/Option.test.ts
+++ b/packages/result/tests/Option.test.ts
@@ -1,11 +1,8 @@
-import { Option, OptionError, Result } from '../src/index';
+import { err, none, ok, Option, OptionError, some } from '../src/index';
 import type { None } from '../src/lib/Option/None';
 import type { Some } from '../src/lib/Option/Some';
 import type { Err } from '../src/lib/Result/Err';
 import type { Ok } from '../src/lib/Result/Ok';
-
-const { some, none, from } = Option;
-const { ok, err } = Result;
 
 describe('Option', () => {
 	describe('prototype', () => {
@@ -744,6 +741,8 @@ describe('Option', () => {
 	});
 
 	describe('from', () => {
+		const { from } = Option;
+
 		test('GIVEN from(T) THEN returns Some', () => {
 			const x = from(42);
 

--- a/packages/result/tests/Result.test.ts
+++ b/packages/result/tests/Result.test.ts
@@ -1,11 +1,8 @@
-import { Option, Result, ResultError } from '../src/index';
+import { err, none, ok, Option, Result, ResultError, some } from '../src/index';
 import type { None } from '../src/lib/Option/None';
 import type { Some } from '../src/lib/Option/Some';
 import type { Err } from '../src/lib/Result/Err';
 import type { Ok } from '../src/lib/Result/Ok';
-
-const { ok, err, from, fromAsync } = Result;
-const { some, none } = Option;
 
 describe('Result', () => {
 	describe('prototype', () => {
@@ -756,6 +753,8 @@ describe('Result', () => {
 	});
 
 	describe('from', () => {
+		const { from } = Result;
+
 		test('GIVEN from(T) value THEN returns Ok', () => {
 			const x = from(42);
 
@@ -802,6 +801,8 @@ describe('Result', () => {
 	});
 
 	describe('fromAsync', () => {
+		const { fromAsync } = Result;
+
 		test('GIVEN fromAsync(T) THEN returns Ok', async () => {
 			const x = await fromAsync(42);
 


### PR DESCRIPTION
The README's code wasn't... correct at all.

Also re-exports `ok`, `err`, `some`, and `none` for convenience and for parity with Rust.
