### PR TITLE
fix(result): better `unwrapOr*`, added more tests

### DIFF
--- a/packages/result/src/lib/Option/IOption.ts
+++ b/packages/result/src/lib/Option/IOption.ts
@@ -130,7 +130,7 @@ export interface IOption<T> {
 	 *
 	 * @see {@link https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or}
 	 */
-	unwrapOr(defaultValue: T): T;
+	unwrapOr<V>(defaultValue: V): T | V;
 
 	/**
 	 * Returns the contained Some value or computes it from a closure.
@@ -146,7 +146,7 @@ export interface IOption<T> {
 	 *
 	 * @see {@link https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_else}
 	 */
-	unwrapOrElse(cb: () => T): T;
+	unwrapOrElse<V>(cb: () => V): T | V;
 
 	/**
 	 * Maps an `Option<T>` to `Option<U>` by applying a function to a contained value.

--- a/packages/result/src/lib/Option/Some.ts
+++ b/packages/result/src/lib/Option/Some.ts
@@ -34,12 +34,12 @@ export class Some<T> implements IOption<T> {
 		return this.value;
 	}
 
-	public unwrapOr(defaultValue: T): T;
+	public unwrapOr(defaultValue: unknown): T;
 	public unwrapOr(): T {
 		return this.value;
 	}
 
-	public unwrapOrElse(cb: () => T): T;
+	public unwrapOrElse(cb: () => unknown): T;
 	public unwrapOrElse(): T {
 		return this.value;
 	}

--- a/packages/result/src/lib/Result/IResult.ts
+++ b/packages/result/src/lib/Result/IResult.ts
@@ -513,7 +513,7 @@ export interface IResult<T, E> {
 	 *
 	 * @see {@link https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_or}
 	 */
-	unwrapOr(defaultValue: T): T;
+	unwrapOr<V>(defaultValue: V): T | V;
 
 	/**
 	 * Returns the contained `Ok` value or computes it from a closure.
@@ -529,7 +529,7 @@ export interface IResult<T, E> {
 	 *
 	 * @see {@link https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_or_else}
 	 */
-	unwrapOrElse(op: (error: E) => T): T;
+	unwrapOrElse<V>(op: (error: E) => V): T | V;
 
 	/**
 	 * Returns `result` if the result is `Ok`, otherwise returns the `Err` value of itself.

--- a/packages/result/src/lib/Result/Ok.ts
+++ b/packages/result/src/lib/Result/Ok.ts
@@ -106,12 +106,12 @@ export class Ok<T> implements IResult<T, any> {
 		throw new ResultError('Unwrap failed', this.value);
 	}
 
-	public unwrapOr(defaultValue: T): T;
+	public unwrapOr(defaultValue: unknown): T;
 	public unwrapOr(): T {
 		return this.value;
 	}
 
-	public unwrapOrElse(op: (error: any) => T): T;
+	public unwrapOrElse(op: (error: any) => unknown): T;
 	public unwrapOrElse(): T {
 		return this.value;
 	}

--- a/packages/result/tests/Option.test.ts
+++ b/packages/result/tests/Option.test.ts
@@ -101,6 +101,12 @@ describe('Option', () => {
 
 				expect<5>(x.unwrapOr(5)).toBe(5);
 			});
+
+			test('GIVEN Option<T> THEN returns union', () => {
+				const x = some(2) as Option<number>;
+
+				expect<number | null>(x.unwrapOr(null)).toBe(2);
+			});
 		});
 
 		describe('unwrapOrElse', () => {
@@ -114,6 +120,12 @@ describe('Option', () => {
 				const x = none;
 
 				expect<5>(x.unwrapOrElse(() => 5)).toBe(5);
+			});
+
+			test('GIVEN Option<T> THEN returns union', () => {
+				const x = some(2) as Option<number>;
+
+				expect<number | null>(x.unwrapOrElse(() => null)).toBe(2);
 			});
 		});
 
@@ -828,6 +840,16 @@ describe('Option', () => {
 
 			expect(x.isSome()).toBe(false);
 			expect(x.isNone()).toBe(true);
+		});
+	});
+
+	describe('types', () => {
+		test('GIVEN Some<T> THEN assigns to Option<T>', () => {
+			expect<Option<string>>(some('foo'));
+		});
+
+		test('GIVEN None THEN assigns to Option<T>', () => {
+			expect<Option<string>>(none);
 		});
 	});
 });

--- a/packages/result/tests/Result.test.ts
+++ b/packages/result/tests/Result.test.ts
@@ -232,7 +232,7 @@ describe('Result', () => {
 				const x = ok(2);
 				const cb = vi.fn((error: string) => ok(error.length));
 
-				expect<Result<number, number>>(x.mapErr(cb)).toBe(x);
+				expect<Result<number, number>>(x.mapErrInto(cb)).toBe(x);
 				expect(cb).not.toHaveBeenCalled();
 			});
 
@@ -409,6 +409,12 @@ describe('Result', () => {
 
 				expect<5>(x.unwrapOr(5)).toBe(5);
 			});
+
+			test('GIVEN Result<T, E> THEN returns union', () => {
+				const x = ok(2) as Result<number, string>;
+
+				expect<number | null>(x.unwrapOr(null)).toBe(2);
+			});
 		});
 
 		describe('unwrapOrElse', () => {
@@ -422,6 +428,12 @@ describe('Result', () => {
 				const x = err('Some error message');
 
 				expect<5>(x.unwrapOrElse(() => 5)).toBe(5);
+			});
+
+			test('GIVEN Result<T, E> THEN returns union', () => {
+				const x = ok(2) as Result<number, string>;
+
+				expect<number | null>(x.unwrapOrElse(() => null)).toBe(2);
 			});
 		});
 
@@ -905,6 +917,16 @@ describe('Result', () => {
 			expect(x.isOk()).toBe(false);
 			expect(x.isErr()).toBe(true);
 			expect(x.unwrapErr()).toBe(error);
+		});
+	});
+
+	describe('types', () => {
+		test('GIVEN Ok<T> THEN assigns to Result<T, E>', () => {
+			expect<Result<number, string>>(ok(4));
+		});
+
+		test('GIVEN Err<E> THEN assigns to Result<T, E>', () => {
+			expect<Result<number, string>>(err('foo'));
 		});
 	});
 });


### PR DESCRIPTION
#415 but fixed.

Please make sure it's *satisfiable*, and that it solves the type issues you had, @Favna.
