### PR TITLE
feat/discordjs utilities migrate runsOnInteraction

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -3,7 +3,6 @@ import type { APIMessage } from 'discord-api-types/v9';
 import type {
 	ButtonInteraction,
 	CommandInteraction,
-	ContextMenuInteraction,
 	ExcludeEnum,
 	Guild,
 	Interaction,
@@ -28,6 +27,7 @@ import type {
 	WebhookEditMessageOptions
 } from 'discord.js';
 import type { MessageButtonStyles, MessageComponentTypes } from 'discord.js/typings/enums';
+import type { AnyInteraction } from '../utility-types';
 import type { PaginatedMessage } from './PaginatedMessage';
 
 export type PaginatedMessageAction = PaginatedMessageActionButton | PaginatedMessageActionLink | PaginatedMessageActionMenu;
@@ -196,7 +196,7 @@ export interface PaginatedMessageInternationalizationContext {
 }
 
 export interface SafeReplyToInteractionParameters<T extends 'edit' | 'reply' | never = never> {
-	messageOrInteraction: APIMessage | Message | CommandInteraction | ContextMenuInteraction | SelectMenuInteraction | ButtonInteraction;
+	messageOrInteraction: APIMessage | Message | AnyInteraction;
 	interactionEditReplyContent: WebhookEditMessageOptions;
 	interactionReplyContent: InteractionReplyOptions;
 	componentUpdateContent: InteractionUpdateOptions;

--- a/packages/discord.js-utilities/src/lib/type-guards.ts
+++ b/packages/discord.js-utilities/src/lib/type-guards.ts
@@ -1,8 +1,9 @@
 import { isNullish, Nullish } from '@sapphire/utilities';
-import type { APIGuildMember, APIInteractionGuildMember, APIMessage, APIInteractionDataResolvedGuildMember } from 'discord-api-types/v9';
+import type { APIGuildMember, APIInteractionDataResolvedGuildMember, APIInteractionGuildMember, APIMessage } from 'discord-api-types/v9';
 import {
 	GuildMember,
 	Message,
+	type BaseCommandInteraction,
 	type BaseGuildVoiceChannel,
 	type CategoryChannel,
 	type Channel,
@@ -16,7 +17,13 @@ import {
 	type ThreadChannel,
 	type VoiceChannel
 } from 'discord.js';
-import type { ChannelTypes, GuildTextBasedChannelTypes, NonThreadGuildTextBasedChannelTypes, TextBasedChannelTypes } from './utility-types';
+import type {
+	AnyInteraction,
+	ChannelTypes,
+	GuildTextBasedChannelTypes,
+	NonThreadGuildTextBasedChannelTypes,
+	TextBasedChannelTypes
+} from './utility-types';
 
 /**
  * Checks whether a given channel is a {@link CategoryChannel}
@@ -188,6 +195,17 @@ export function isNsfwChannel(channel: ChannelTypes | Nullish): boolean {
  */
 export function isMessageInstance(message: APIMessage | Message): message is Message {
 	return message instanceof Message;
+}
+
+/**
+ * Checks whether the input `messageOrInteraction` is one of {@link Message} or one of {@link BaseCommandInteraction}, {@link CommandInteraction}, {@link ContextMenuInteraction}, or {@link SelectMenuInteraction}
+ * @param messageOrInteraction The message or interaction that should be checked.
+ * @returns `true` if the `messageOrInteraction` is **NOT** an instanceof {@link Message}, `false` if it is.
+ */
+export function isAnyInteraction(
+	messageOrInteraction: APIMessage | Message | BaseCommandInteraction | AnyInteraction
+): messageOrInteraction is AnyInteraction {
+	return !(messageOrInteraction instanceof Message);
 }
 
 /**

--- a/packages/discord.js-utilities/src/lib/utility-types.ts
+++ b/packages/discord.js-utilities/src/lib/utility-types.ts
@@ -1,11 +1,16 @@
 import type {
+	ButtonInteraction,
 	CategoryChannel,
 	Channel,
+	CommandInteraction,
+	ContextMenuInteraction,
 	DMChannel,
 	GuildChannel,
 	Message,
+	ModalSubmitInteraction,
 	NewsChannel,
 	PartialDMChannel,
+	SelectMenuInteraction,
 	StageChannel,
 	StoreChannel,
 	TextChannel,
@@ -63,3 +68,18 @@ export type GuildTextBasedChannelTypes = NonThreadGuildTextBasedChannelTypes | T
  * The types of a channel, with the addition of `'UNKNOWN'`
  */
 export type ChannelTypeString = ChannelTypes['type'] | 'UNKNOWN';
+
+/**
+ * A union of {@link CommandInteraction} and {@link ContextMenuInteraction}. Similar to {@link BaseCommandInteraction} class but as a type union.
+ */
+export type ChatInputOrContextMenuInteraction = CommandInteraction | ContextMenuInteraction;
+
+/**
+ * A union of {@link CommandInteraction}, {@link ContextMenuInteraction}, {@link SelectMenuInteraction}, {@link ButtonInteraction}, and {@link ModalSubmitInteraction};
+ */
+export type NonModalInteraction = ChatInputOrContextMenuInteraction | SelectMenuInteraction | ButtonInteraction;
+
+/**
+ * A union of {@link CommandInteraction}, {@link ContextMenuInteraction}, {@link SelectMenuInteraction}, {@link ButtonInteraction}, and {@link ModalSubmitInteraction};
+ */
+export type AnyInteraction = ChatInputOrContextMenuInteraction | SelectMenuInteraction | ButtonInteraction | ModalSubmitInteraction;

--- a/packages/discord.js-utilities/src/lib/utility-types.ts
+++ b/packages/discord.js-utilities/src/lib/utility-types.ts
@@ -82,4 +82,4 @@ export type NonModalInteraction = ChatInputOrContextMenuInteraction | SelectMenu
 /**
  * A union of {@link CommandInteraction}, {@link ContextMenuInteraction}, {@link SelectMenuInteraction}, {@link ButtonInteraction}, and {@link ModalSubmitInteraction};
  */
-export type AnyInteraction = ChatInputOrContextMenuInteraction | SelectMenuInteraction | ButtonInteraction | ModalSubmitInteraction;
+export type AnyInteraction = NonModalInteraction | ModalSubmitInteraction;


### PR DESCRIPTION
needs rebase

- feat(discord.js-utilities): add `ChatInputOrContextMenuInteraction`, `NonModalInteraction`, and `AnyInteraction` utility types
- feat(discord.js-utilities): rename `runsOnInteraction` to `isAnyInteraction` and add deprecation notice for the former
