### PR TITLE
feat: add `AsyncQueue#abortAll`

### DIFF
--- a/packages/async-queue/src/lib/AsyncQueueEntry.ts
+++ b/packages/async-queue/src/lib/AsyncQueueEntry.ts
@@ -34,14 +34,23 @@ export class AsyncQueueEntry {
 	}
 
 	public use() {
+		this.dispose();
+		this.resolve();
+		return this;
+	}
+
+	public abort() {
+		this.dispose();
+		this.reject(new Error('Request aborted manually'));
+		return this;
+	}
+
+	private dispose() {
 		if (this.signal) {
 			this.signal.removeEventListener('abort', this.signalListener!);
 			this.signal = null;
 			this.signalListener = null;
 		}
-
-		this.resolve();
-		return this;
 	}
 }
 


### PR DESCRIPTION
Too Many Requests on AQ, but this should make https://github.com/discordjs/discord.js/issues/8497 a lot more efficient.

Also added `AsyncQueue#queued` which makes more sense to have now that we have a head system.