### PR TITLE
feat: add `intoPromise`

### DIFF
--- a/packages/result/src/lib/Option/IOption.ts
+++ b/packages/result/src/lib/Option/IOption.ts
@@ -659,6 +659,19 @@ export interface IOption<T> {
 	flatten<IT>(this: Option<Option<IT>>): Option<IT>;
 
 	/**
+	 * Returns a `Promise` object with the awaited value (if `Some`).
+	 *
+	 * @example
+	 * ```typescript
+	 * let x = some(Promise.resolve(3));
+	 * assert.equal(await x.intoPromise(), some(3));
+	 * ```
+	 *
+	 * @note This is an extension not supported in Rust
+	 */
+	intoPromise(): Promise<Option<Awaited<T>>>;
+
+	/**
 	 * Checks whether or not `other` equals with self.
 	 * @param other The other option to compare.
 	 *

--- a/packages/result/src/lib/Option/None.ts
+++ b/packages/result/src/lib/Option/None.ts
@@ -139,6 +139,10 @@ export class None implements IOption<any> {
 		return this;
 	}
 
+	public intoPromise(): Promise<None> {
+		return Promise.resolve(none);
+	}
+
 	public eq(other: None): true;
 	public eq(other: Some<any>): false;
 	public eq(other: Option<any>): boolean;

--- a/packages/result/src/lib/Option/Some.ts
+++ b/packages/result/src/lib/Option/Some.ts
@@ -158,6 +158,10 @@ export class Some<T> implements IOption<T> {
 		return this.value;
 	}
 
+	public async intoPromise(): Promise<Some<Awaited<T>>> {
+		return some(await this.value);
+	}
+
 	public eq(other: None): false;
 	public eq(other: Option<T>): boolean;
 	public eq(other: Option<T>): boolean {

--- a/packages/result/src/lib/Result/Err.ts
+++ b/packages/result/src/lib/Result/Err.ts
@@ -154,6 +154,10 @@ export class Err<E> implements IResult<any, E> {
 		return this.error;
 	}
 
+	public async intoPromise(): Promise<Err<Awaited<E>>> {
+		return err(await this.error);
+	}
+
 	public eq(other: Ok<any>): false;
 	public eq(other: Result<any, E>): boolean;
 	public eq(other: Result<any, E>): boolean {

--- a/packages/result/src/lib/Result/IResult.ts
+++ b/packages/result/src/lib/Result/IResult.ts
@@ -742,6 +742,19 @@ export interface IResult<T, E> {
 	intoOkOrErr(): T | E;
 
 	/**
+	 * Returns a `Promise` object with the awaited value (if `Ok`) or the awaited error (if `Err`).
+	 *
+	 * @example
+	 * ```typescript
+	 * let x = ok(Promise.resolve(3));
+	 * assert.equal(await x.intoPromise(), ok(3));
+	 * ```
+	 *
+	 * @note This is an extension not supported in Rust
+	 */
+	intoPromise(): Promise<Result<Awaited<T>, Awaited<E>>>;
+
+	/**
 	 * Checks whether or not `other` equals with self.
 	 * @param other The other result to compare.
 	 *

--- a/packages/result/src/lib/Result/Ok.ts
+++ b/packages/result/src/lib/Result/Ok.ts
@@ -161,6 +161,10 @@ export class Ok<T> implements IResult<T, any> {
 		return this.value;
 	}
 
+	public async intoPromise(): Promise<Ok<Awaited<T>>> {
+		return ok(await this.value);
+	}
+
 	public eq(other: Err<any>): false;
 	public eq(other: Result<T, any>): boolean;
 	public eq(other: Result<T, any>): boolean {

--- a/packages/result/tests/Option.test.ts
+++ b/packages/result/tests/Option.test.ts
@@ -655,6 +655,20 @@ describe('Option', () => {
 			});
 		});
 
+		describe('intoPromise', () => {
+			test('GIVEN some(Promise(s)) THEN returns Promise(some(s))', async () => {
+				const x = some(Promise.resolve(3));
+
+				await expect<Promise<Some<number>>>(x.intoPromise()).resolves.toEqual(some(3));
+			});
+
+			test('GIVEN none THEN returns Promise(none)', async () => {
+				const x = none;
+
+				await expect<Promise<None>>(x.intoPromise()).resolves.toEqual(none);
+			});
+		});
+
 		describe('eq', () => {
 			test('GIVEN x=some(s), y=some(s) THEN returns true', () => {
 				const x = some(3);

--- a/packages/result/tests/Result.test.ts
+++ b/packages/result/tests/Result.test.ts
@@ -674,6 +674,20 @@ describe('Result', () => {
 			});
 		});
 
+		describe('intoPromise', () => {
+			test('GIVEN ok(Promise(s)) THEN returns Promise(ok(s))', async () => {
+				const x = ok(Promise.resolve(3));
+
+				await expect<Promise<Ok<number>>>(x.intoPromise()).resolves.toEqual(ok(3));
+			});
+
+			test('GIVEN err(Promise(e)) THEN returns Promise(err(e))', async () => {
+				const x = err(Promise.resolve(3));
+
+				await expect<Promise<Err<number>>>(x.intoPromise()).resolves.toEqual(err(3));
+			});
+		});
+
 		describe('eq', () => {
 			test('GIVEN x=ok(s), y=ok(s) THEN returns true', () => {
 				const x = ok(3);


### PR DESCRIPTION
This comes very handy for swapping Results and Options with Promises, take the example below:

```typescript
const result = await Result.fromAsync(fetch('https://example.org/image.png'));

return result
	.map(async (response) => {
		const blob = await response.blob();
		return { name: 'image.png', data: await blob.arrayBuffer(), type: blob.type };
	})
	.intoPromise();
```

Which is a lot more idiomatic than:

```typescript
const result = await Result.fromAsync(fetch('https://example.org/image.png'));

return result.match({
	ok: async (response) => {
		const blob = await response.blob();
		return { name: 'image.png', data: await blob.arrayBuffer(), type: blob.type };
	},
	err: (error) => Promise.resolve(err(error))
});
```
