### PR TITLE
fix(isNumber): parse string parameter as number (allow string as parameter)

### DIFF
--- a/packages/utilities/src/lib/isNumber.ts
+++ b/packages/utilities/src/lib/isNumber.ts
@@ -3,5 +3,6 @@
  * @param input The number to verify
  */
 export function isNumber(input: unknown): input is number {
+	if (typeof input === 'string') input = Number(input);
 	return typeof input === 'number' && !isNaN(input) && Number.isFinite(input);
 }

--- a/packages/utilities/src/lib/isNumber.ts
+++ b/packages/utilities/src/lib/isNumber.ts
@@ -4,5 +4,5 @@
  */
 export function isNumber(input: unknown): input is number {
 	if (typeof input === 'string') input = Number(input);
-	return typeof input === 'number' && !isNaN(input) && Number.isFinite(input);
+	return typeof input === 'number' && !Number.isNaN(input) && Number.isFinite(input);
 }


### PR DESCRIPTION
This PR is due to the fact that this utility cannot accept a string as a value, so what has to be done is:

```ts
const numberString = '1';
isNumber(Number(numberString));
```

With this PR you will now be able to do the following:

```ts
const numberString = '1';
isNumber(numberString);
```

This helps for example, if you have an API and you receive a query parameter, this will come in string type, with this you can validate directly without the need to convert it to a number manually.