### PR TITLE
feat(utilities): add `sleep` and `sleepSync`

### DIFF
--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -39,7 +39,7 @@ export * from './lib/range';
 export * from './lib/regExpEsc';
 export * from './lib/roundNumber';
 export * from './lib/splitText';
-export { AbortError, sleep, sleepSync, type SleepOptions } from './lib/sleep';
+export * from './lib/sleep';
 export { toTitleCase, ToTitleCaseOptions } from './lib/toTitleCase';
 export * from './lib/tryParse';
 export * from './lib/utilityTypes';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -39,7 +39,7 @@ export * from './lib/range';
 export * from './lib/regExpEsc';
 export * from './lib/roundNumber';
 export * from './lib/splitText';
-export * from './lib/sleep';
+export { AbortError, sleep, sleepSync, type SleepOptions } from './lib/sleep';
 export { toTitleCase, ToTitleCaseOptions } from './lib/toTitleCase';
 export * from './lib/tryParse';
 export * from './lib/utilityTypes';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -39,6 +39,7 @@ export * from './lib/range';
 export * from './lib/regExpEsc';
 export * from './lib/roundNumber';
 export * from './lib/splitText';
+export * from './lib/sleep';
 export { toTitleCase, ToTitleCaseOptions } from './lib/toTitleCase';
 export * from './lib/tryParse';
 export * from './lib/utilityTypes';

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -13,17 +13,16 @@ export interface SleepOptions {
 }
 
 export class AbortError extends Error {
-	public code: string;
+	public readonly code: string;
 	public constructor(
 		message?: string,
 		options?: {
 			cause?: unknown;
-			code?: string;
 		}
 	) {
 		super(message, options);
 		this.name = 'AbortError';
-		this.code = options?.code ?? 'ERR_ABORT';
+		this.code = 'ERR_ABORT';
 	}
 }
 
@@ -36,12 +35,13 @@ export class AbortError extends Error {
 export function sleep<T = undefined>(ms: number, value?: T, options?: SleepOptions): Promise<T> {
 	return new Promise((resolve, reject) => {
 		const timer: NodeJS.Timeout | number = setTimeout(() => resolve(value!), ms);
-		if (options?.signal) {
-			options.signal.addEventListener('abort', () => {
+		const signal = options?.signal;
+		if (signal) {
+			signal.addEventListener('abort', () => {
 				clearTimeout(timer);
 				reject(
 					new AbortError('The operation was aborted', {
-						cause: options.signal!.reason
+						cause: signal.reason
 					})
 				);
 			});

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -1,21 +1,67 @@
+export interface Abortable {
+	/**
+	 * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
+	 */
+	signal?: AbortSignal | undefined;
+}
+
+export interface TimerOptions extends Abortable {
+	/**
+	 * Set to `false` to indicate that the scheduled `Timeout`
+	 * should not require the Node.js event loop to remain active.
+	 * @default true
+	 */
+	ref?: boolean | undefined;
+}
+
+export class AbortError extends Error {
+	public code: string;
+	public constructor(
+		message?: string,
+		options?: {
+			cause?: unknown;
+			code?: string;
+		}
+	) {
+		super(message, options);
+		this.name = 'AbortError';
+		this.code = options?.code ?? 'ERR_ABORT';
+	}
+}
+
 /**
  * Sleeps for the specified number of milliseconds.
  * @param ms The number of milliseconds to sleep.
- * @param value The value to resolve the promise with.
+ * @param value A value with which the promise is fulfilled.
  * @see {@link sleepSync} for a synchronous version.
  */
-export function sleep<T = undefined>(ms: number, value?: T): Promise<T> {
-	return new Promise((resolve) => setTimeout(() => resolve(value!), ms));
+export function sleep<T = undefined>(ms: number, value?: T, options?: TimerOptions): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timer: NodeJS.Timeout | number = setTimeout(() => resolve(value!), ms);
+		if (options?.signal) {
+			options.signal.addEventListener('abort', () => {
+				clearTimeout(timer);
+				reject(
+					new AbortError('The operation was aborted', {
+						cause: new DOMException('The operation was aborted', 'AbortError')
+					})
+				);
+			});
+		}
+		if (options?.ref === false && typeof timer === 'object') {
+			timer.unref();
+		}
+	});
 }
 
 /**
  * Sleeps for the specified number of milliseconds synchronously.
  * @param ms The number of milliseconds to sleep.
- * @param value The value to return.
+ * @param value A value to return.
  * @see {@link sleep} for an asynchronous version.
  */
 export function sleepSync<T = undefined>(ms: number, value?: T): T {
 	const start = Date.now();
-	while (Date.now() - start < ms) continue;
+	while (Date.now() - start <= ms) continue;
 	return value!;
 }

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -29,6 +29,18 @@ export class AbortError extends Error {
 	}
 }
 
+const DOMException: typeof globalThis.DOMException =
+	globalThis.DOMException ??
+	(() => {
+		// DOMException was only made a global in Node v17.0.0,
+		// but we support >= v14.
+		try {
+			atob('~');
+		} catch (err) {
+			return Object.getPrototypeOf(err).constructor;
+		}
+	})();
+
 /**
  * Sleeps for the specified number of milliseconds.
  * @param ms The number of milliseconds to sleep.

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -27,18 +27,6 @@ export class AbortError extends Error {
 	}
 }
 
-export const DOMException: typeof globalThis.DOMException =
-	globalThis.DOMException ??
-	(() => {
-		// DOMException was only made a global in Node v17.0.0,
-		// but we support >= v14
-		try {
-			atob('~');
-		} catch (err) {
-			return Object.getPrototypeOf(err).constructor;
-		}
-	})();
-
 /**
  * Sleeps for the specified number of milliseconds.
  * @param ms The number of milliseconds to sleep.
@@ -53,7 +41,7 @@ export function sleep<T = undefined>(ms: number, value?: T, options?: SleepOptio
 				clearTimeout(timer);
 				reject(
 					new AbortError('The operation was aborted', {
-						cause: new DOMException('The operation was aborted', 'AbortError')
+						cause: options.signal!.reason
 					})
 				);
 			});

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -59,7 +59,7 @@ export function sleep<T = undefined>(ms: number, value?: T, options?: SleepOptio
  * @see {@link sleep} for an asynchronous version.
  */
 export function sleepSync<T = undefined>(ms: number, value?: T): T {
-	const start = Date.now();
-	while (Date.now() - start <= ms) continue;
+	const end = Date.now() + ms;
+	while (Date.now() <= end) continue;
 	return value!;
 }

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -54,6 +54,9 @@ export function sleep<T = undefined>(ms: number, value?: T, options?: SleepOptio
 
 /**
  * Sleeps for the specified number of milliseconds synchronously.
+ * We should probably note that unlike {@link sleep} (which uses CPU tick times),
+ * sleepSync uses wall clock times, so the precision is near-absolute by comparison.
+ * That, and that synchronous means that nothing else in the thread will run for the length of the timer.
  * @param ms The number of milliseconds to sleep.
  * @param value A value to return.
  * @see {@link sleep} for an asynchronous version.

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -60,6 +60,6 @@ export function sleep<T = undefined>(ms: number, value?: T, options?: SleepOptio
  */
 export function sleepSync<T = undefined>(ms: number, value?: T): T {
 	const end = Date.now() + ms;
-	while (Date.now() <= end) continue;
+	while (Date.now() < end) continue;
 	return value!;
 }

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line spaced-comment
-/// <reference lib="dom" />
 export interface SleepOptions {
 	/**
 	 * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
 export interface SleepOptions {
 	/**
 	 * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -1,11 +1,9 @@
-export interface Abortable {
+export interface SleepOptions {
 	/**
 	 * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
 	 */
 	signal?: AbortSignal | undefined;
-}
 
-export interface TimerOptions extends Abortable {
 	/**
 	 * Set to `false` to indicate that the scheduled `Timeout`
 	 * should not require the Node.js event loop to remain active.
@@ -29,11 +27,11 @@ export class AbortError extends Error {
 	}
 }
 
-const DOMException: typeof globalThis.DOMException =
+export const DOMException: typeof globalThis.DOMException =
 	globalThis.DOMException ??
 	(() => {
 		// DOMException was only made a global in Node v17.0.0,
-		// but we support >= v14.
+		// but we support >= v14
 		try {
 			atob('~');
 		} catch (err) {
@@ -47,7 +45,7 @@ const DOMException: typeof globalThis.DOMException =
  * @param value A value with which the promise is fulfilled.
  * @see {@link sleepSync} for a synchronous version.
  */
-export function sleep<T = undefined>(ms: number, value?: T, options?: TimerOptions): Promise<T> {
+export function sleep<T = undefined>(ms: number, value?: T, options?: SleepOptions): Promise<T> {
 	return new Promise((resolve, reject) => {
 		const timer: NodeJS.Timeout | number = setTimeout(() => resolve(value!), ms);
 		if (options?.signal) {

--- a/packages/utilities/src/lib/sleep.ts
+++ b/packages/utilities/src/lib/sleep.ts
@@ -1,0 +1,21 @@
+/**
+ * Sleeps for the specified number of milliseconds.
+ * @param ms The number of milliseconds to sleep.
+ * @param value The value to resolve the promise with.
+ * @see {@link sleepSync} for a synchronous version.
+ */
+export function sleep<T = undefined>(ms: number, value?: T): Promise<T> {
+	return new Promise((resolve) => setTimeout(() => resolve(value!), ms));
+}
+
+/**
+ * Sleeps for the specified number of milliseconds synchronously.
+ * @param ms The number of milliseconds to sleep.
+ * @param value The value to return.
+ * @see {@link sleep} for an asynchronous version.
+ */
+export function sleepSync<T = undefined>(ms: number, value?: T): T {
+	const start = Date.now();
+	while (Date.now() - start < ms) continue;
+	return value!;
+}

--- a/packages/utilities/src/tsconfig.json
+++ b/packages/utilities/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../ts-config/extra-strict-without-decorators.json",
 	"compilerOptions": {
+		"lib": ["dom", "esnext"],
 		"rootDir": "./",
 		"outDir": "../dist",
 		"incremental": false

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -1,0 +1,31 @@
+import { sleep, sleepSync } from '../src';
+
+describe('sleep', () => {
+	test('GIVEN a number of ms THEN resolve the promise after that time', async () => {
+		const start = Date.now();
+		await sleep(100);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+	});
+
+	test('GIVEN a number of ms and a value THEN resolve the promise after that time with the value', async () => {
+		const start = Date.now();
+		const value = await sleep(100, 'test');
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		expect<string>(value).toBe('test');
+	});
+});
+
+describe('sleepSync', () => {
+	test('GIVEN a number of ms THEN return after that time', () => {
+		const start = Date.now();
+		sleepSync(100);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+	});
+
+	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
+		const start = Date.now();
+		const value = sleepSync(100, 'test');
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		expect<string>(value).toBe('test');
+	});
+});

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -17,13 +17,13 @@ describe('sleep', () => {
 	test('GIVEN a number of ms THEN resolve the promise after that time', async () => {
 		const start = Date.now();
 		await sleep(50);
-		expect(Date.now() - start).closeTo(50, 15);
+		expect(Date.now() - start).greaterThanOrEqual(45);
 	});
 
 	test('GIVEN a number of ms and a value THEN resolve the promise after that time with the value', async () => {
 		const start = Date.now();
 		const value = await sleep(50, 'test');
-		expect(Date.now() - start).closeTo(50, 15);
+		expect(Date.now() - start).greaterThanOrEqual(45);
 		expect<string>(value).toBe('test');
 	});
 
@@ -56,13 +56,13 @@ describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
 		sleepSync(50);
-		expect(Date.now() - start).closeTo(50, 15);
+		expect(Date.now() - start).greaterThanOrEqual(45);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
 		const value = sleepSync(50, 'test');
-		expect(Date.now() - start).closeTo(50, 15);
+		expect(Date.now() - start).greaterThanOrEqual(45);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -56,13 +56,13 @@ describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
 		sleepSync(50);
-		expect(Date.now() - start).greaterThanOrEqual(45);
+		expect(Date.now() - start).greaterThanOrEqual(50);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
 		const value = sleepSync(50, 'test');
-		expect(Date.now() - start).greaterThanOrEqual(45);
+		expect(Date.now() - start).greaterThanOrEqual(50);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -1,18 +1,29 @@
 import { AbortError, sleep, sleepSync } from '../src';
-import { DOMException } from '../src/lib/sleep';
 import { expectError } from './util/macros/comparators';
+
+const DOMException: typeof globalThis.DOMException =
+	globalThis.DOMException ??
+	(() => {
+		// DOMException was only made a global in Node v17.0.0,
+		// but our CI runs on Node v16.6.0 too
+		try {
+			atob('~');
+		} catch (err) {
+			return Object.getPrototypeOf(err).constructor;
+		}
+	})();
 
 describe('sleep', () => {
 	test('GIVEN a number of ms THEN resolve the promise after that time', async () => {
 		const start = Date.now();
-		await sleep(1000);
-		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
+		await sleep(50);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
 	});
 
 	test('GIVEN a number of ms and a value THEN resolve the promise after that time with the value', async () => {
 		const start = Date.now();
-		const value = await sleep(1000, 'test');
-		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
+		const value = await sleep(50, 'test');
+		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
 		expect<string>(value).toBe('test');
 	});
 
@@ -23,7 +34,19 @@ describe('sleep', () => {
 		await expectError(
 			() => promise,
 			new AbortError('The operation was aborted', {
-				cause: new DOMException('The operation was aborted', 'AbortError')
+				cause: new DOMException('This operation was aborted', 'AbortError')
+			})
+		);
+	});
+
+	test('GIVEN a abort signal with reason THEN reject the promise with the reason as cause', async () => {
+		const controller = new AbortController();
+		const promise = sleep(1000, 'test', { signal: controller.signal });
+		controller.abort('test');
+		await expectError(
+			() => promise,
+			new AbortError('The operation was aborted', {
+				cause: 'test'
 			})
 		);
 	});
@@ -32,14 +55,14 @@ describe('sleep', () => {
 describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
-		sleepSync(1000);
-		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
+		sleepSync(50);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
-		const value = sleepSync(1000, 'test');
-		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
+		const value = sleepSync(50, 'test');
+		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -1,4 +1,5 @@
-import { AbortError, DOMException, sleep, sleepSync } from '../src';
+import { AbortError, sleep, sleepSync } from '../src';
+import { DOMException } from '../src/lib/sleep';
 import { expectError } from './util/macros/comparators';
 
 describe('sleep', () => {

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -13,6 +13,13 @@ describe('sleep', () => {
 		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
 		expect<string>(value).toBe('test');
 	});
+
+	test('GIVEN a abort signal THEN reject the promise', async () => {
+		const controller = new AbortController();
+		const promise = sleep(1000, 'test', { signal: controller.signal });
+		controller.abort();
+		await expect(promise).rejects.toThrow('The operation was aborted');
+	});
 });
 
 describe('sleepSync', () => {

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -56,13 +56,13 @@ describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
 		sleepSync(50);
-		expect(Date.now() - start).toBe(50);
+		expect(Date.now() - start).oneOf([50, 51]);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
 		const value = sleepSync(50, 'test');
-		expect(Date.now() - start).toBe(50);
+		expect(Date.now() - start).oneOf([50, 51]);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -1,16 +1,17 @@
-import { sleep, sleepSync } from '../src';
+import { AbortError, DOMException, sleep, sleepSync } from '../src';
+import { expectError } from './util/macros/comparators';
 
 describe('sleep', () => {
 	test('GIVEN a number of ms THEN resolve the promise after that time', async () => {
 		const start = Date.now();
-		await sleep(100);
-		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		await sleep(1000);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
 	});
 
 	test('GIVEN a number of ms and a value THEN resolve the promise after that time with the value', async () => {
 		const start = Date.now();
-		const value = await sleep(100, 'test');
-		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		const value = await sleep(1000, 'test');
+		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
 		expect<string>(value).toBe('test');
 	});
 
@@ -18,21 +19,26 @@ describe('sleep', () => {
 		const controller = new AbortController();
 		const promise = sleep(1000, 'test', { signal: controller.signal });
 		controller.abort();
-		await expect(promise).rejects.toThrow('The operation was aborted');
+		await expectError(
+			() => promise,
+			new AbortError('The operation was aborted', {
+				cause: new DOMException('The operation was aborted', 'AbortError')
+			})
+		);
 	});
 });
 
 describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
-		sleepSync(100);
-		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		sleepSync(1000);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
-		const value = sleepSync(100, 'test');
-		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		const value = sleepSync(1000, 'test');
+		expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -17,13 +17,13 @@ describe('sleep', () => {
 	test('GIVEN a number of ms THEN resolve the promise after that time', async () => {
 		const start = Date.now();
 		await sleep(50);
-		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
+		expect(Date.now() - start).closeTo(50, 15);
 	});
 
 	test('GIVEN a number of ms and a value THEN resolve the promise after that time with the value', async () => {
 		const start = Date.now();
 		const value = await sleep(50, 'test');
-		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
+		expect(Date.now() - start).closeTo(50, 15);
 		expect<string>(value).toBe('test');
 	});
 
@@ -56,13 +56,13 @@ describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
 		sleepSync(50);
-		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
+		expect(Date.now() - start).closeTo(50, 15);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
 		const value = sleepSync(50, 'test');
-		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
+		expect(Date.now() - start).closeTo(50, 15);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/sleep.test.ts
+++ b/packages/utilities/tests/sleep.test.ts
@@ -56,13 +56,13 @@ describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
 		const start = Date.now();
 		sleepSync(50);
-		expect(Date.now() - start).greaterThanOrEqual(50);
+		expect(Date.now() - start).toBe(50);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
 		const start = Date.now();
 		const value = sleepSync(50, 'test');
-		expect(Date.now() - start).greaterThanOrEqual(50);
+		expect(Date.now() - start).toBe(50);
 		expect<string>(value).toBe('test');
 	});
 });

--- a/packages/utilities/tests/tsconfig.json
+++ b/packages/utilities/tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../ts-config/extra-strict-without-decorators.json",
 	"compilerOptions": {
+		"lib": ["dom", "esnext"],
 		"noEmit": true,
 		"incremental": false,
 		"types": ["vitest/globals"]

--- a/packages/utilities/tests/util/macros/comparators.ts
+++ b/packages/utilities/tests/util/macros/comparators.ts
@@ -1,0 +1,23 @@
+type _Error = Error & { code?: string };
+
+export function IdenticalError(expected: _Error, actual: _Error) {
+	expect(actual).toBeDefined();
+	expect(actual).toBeInstanceOf(expected.constructor);
+	expect(actual.message).toBe(expected.message);
+	if (expected.code) expect(actual.code).toBe(expected.code);
+	if (expected.cause) {
+		if (expected.cause instanceof Error) IdenticalError(expected.cause, actual.cause as _Error);
+		else expect(actual.cause).toBe(expected.cause);
+	}
+}
+
+export async function expectError<T = any>(cb: () => T, expected: Error & { code?: string }) {
+	try {
+		await cb();
+	} catch (error) {
+		IdenticalError(expected, error as _Error);
+		return;
+	}
+
+	throw new Error('Expected to throw, but failed to do so');
+}


### PR DESCRIPTION
This pr adds `sleep` and `sleepAsync` 

I'm not using `timers/promise` just to make it browser compitible