### PR TITLE
feat(result): add `Result.unwrapRaw`

### DIFF
--- a/packages/result/src/lib/Result/Err.ts
+++ b/packages/result/src/lib/Result/Err.ts
@@ -115,6 +115,11 @@ export class Err<E> implements IResult<any, E> {
 		return op(this.error);
 	}
 
+	public unwrapRaw(): never {
+		// eslint-disable-next-line @typescript-eslint/no-throw-literal
+		throw this.error;
+	}
+
 	public and(result?: Result<any, E>): this;
 	public and(): this {
 		return this;

--- a/packages/result/src/lib/Result/IResult.ts
+++ b/packages/result/src/lib/Result/IResult.ts
@@ -532,6 +532,31 @@ export interface IResult<T, E> {
 	unwrapOrElse<V>(op: (error: E) => V): T | V;
 
 	/**
+	 * Returns the contained `Ok` value.
+	 *
+	 * If the value is an `Err`, it throws the contained error.
+	 * @seealso {@link unwrap}
+	 * @seealso {@link unwrapOr}
+	 * @seealso {@link unwrapOrElse}
+	 *
+	 * @example
+	 * ```typescript
+	 * const x = ok(2);
+	 * assert.equal(x.unwrapRaw(), 2);
+	 * ```
+	 * @example
+	 * ```typescript
+	 * const x = err('Emergency failure');
+	 * assert.throws(() => x.unwrapRaw(), {
+	 *   name: 'Error',
+	 *   message: 'Unwrap failed',
+	 *   value: 'Emergency failure'
+	 * });
+	 * ```
+	 */
+	unwrapRaw(): T | never;
+
+	/**
 	 * Returns `result` if the result is `Ok`, otherwise returns the `Err` value of itself.
 	 * @param result The result to check.
 	 *

--- a/packages/result/src/lib/Result/IResult.ts
+++ b/packages/result/src/lib/Result/IResult.ts
@@ -449,6 +449,8 @@ export interface IResult<T, E> {
 	 * If the value is an `Err`, it throws a {@link ResultError} with the message, and the content of the `Err`.
 	 * @seealso {@link unwrapOr}
 	 * @seealso {@link unwrapOrElse}
+	 * @seealso {@link unwrapErr}
+	 * @seealso {@link unwrapRaw}
 	 *
 	 * @example
 	 * ```typescript
@@ -473,6 +475,10 @@ export interface IResult<T, E> {
 	 * Returns the contained `Err` value.
 	 *
 	 * If the value is an `Ok`, it throws a {@link ResultError} with the message, and the content of the `Ok`.
+	 * @seealso {@link unwrap}
+	 * @seealso {@link unwrapOr}
+	 * @seealso {@link unwrapOrElse}
+	 * @seealso {@link unwrapRaw}
 	 *
 	 * @example
 	 * ```typescript
@@ -498,6 +504,11 @@ export interface IResult<T, E> {
 	 *
 	 * Arguments passed to `unwrapOr` are eagerly evaluated; if you are passing the result of a function call, it is
 	 * recommended to use {@link unwrapOrElse}, which is lazily evaluated.
+	 * @seealso {@link unwrap}
+	 * @seealso {@link unwrapOrElse}
+	 * @seealso {@link unwrapErr}
+	 * @seealso {@link unwrapRaw}
+	 *
 	 * @param defaultValue The default value.
 	 *
 	 * @example
@@ -517,6 +528,11 @@ export interface IResult<T, E> {
 
 	/**
 	 * Returns the contained `Ok` value or computes it from a closure.
+	 * @seealso {@link unwrap}
+	 * @seealso {@link unwrapOr}
+	 * @seealso {@link unwrapErr}
+	 * @seealso {@link unwrapRaw}
+	 *
 	 * @param op The predicate.
 	 *
 	 * @example
@@ -538,6 +554,7 @@ export interface IResult<T, E> {
 	 * @seealso {@link unwrap}
 	 * @seealso {@link unwrapOr}
 	 * @seealso {@link unwrapOrElse}
+	 * @seealso {@link unwrapErr}
 	 *
 	 * @example
 	 * ```typescript

--- a/packages/result/src/lib/Result/Ok.ts
+++ b/packages/result/src/lib/Result/Ok.ts
@@ -116,6 +116,10 @@ export class Ok<T> implements IResult<T, any> {
 		return this.value;
 	}
 
+	public unwrapRaw(): T {
+		return this.value;
+	}
+
 	public and<R extends Result<any, any>>(result: R): R {
 		return result;
 	}

--- a/packages/result/tests/Result.test.ts
+++ b/packages/result/tests/Result.test.ts
@@ -438,6 +438,28 @@ describe('Result', () => {
 			});
 		});
 
+		describe('unwrapRaw', () => {
+			test('GIVEN ok THEN returns value', () => {
+				const x = ok(2);
+
+				expect<number>(x.unwrapRaw()).toBe(2);
+			});
+
+			test('GIVEN err THEN throws Error', () => {
+				const x = err(new Error('Some error message'));
+
+				try {
+					x.unwrapRaw();
+				} catch (raw) {
+					const error = raw as Error;
+
+					expect(error).toBeInstanceOf(Error);
+					expect<string>(error.name).toBe('Error');
+					expect<string>(error.message).toBe('Some error message');
+				}
+			});
+		});
+
 		describe('and', () => {
 			test('GIVEN x=ok and y=ok THEN returns y', () => {
 				const x = ok(2);

--- a/packages/result/tests/Result.test.ts
+++ b/packages/result/tests/Result.test.ts
@@ -446,17 +446,10 @@ describe('Result', () => {
 			});
 
 			test('GIVEN err THEN throws Error', () => {
-				const x = err(new Error('Some error message'));
+				const error = new Error('Some error message');
+				const x = err(error);
 
-				try {
-					x.unwrapRaw();
-				} catch (raw) {
-					const error = raw as Error;
-
-					expect(error).toBeInstanceOf(Error);
-					expect<string>(error.name).toBe('Error');
-					expect<string>(error.message).toBe('Some error message');
-				}
+				expect(() => x.unwrapRaw()).toThrowError(error);
 			});
 		});
 


### PR DESCRIPTION
This is essentially a shortcut for:
```ts
	return result.match({
		err: (error) => {
			throw error;
		},
		ok: (value) => value.data[0]
	});
```
which can then be written as:
```ts
return result.map((value) => value.data[0]).unwrapRaw();
```

This is useful when instead of throwing a `ResultError` you want to instead throw the inner error (i.e. `ArgumentError` for Sapphire, see sapphiredev/framework#528, or a `FetchError` from @skyra/safe-fetch, something that brought about this change)