### PR TITLE
fix(utilities): race condition issue for closed paginated message

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1143,9 +1143,10 @@ export class PaginatedMessage {
 	 * @param reason The reason for which the collector was ended.
 	 */
 	protected async handleEnd(_: Collection<Snowflake, ButtonInteraction | SelectMenuInteraction>, reason: string): Promise<void> {
-		// Fix a race condition bug where interacting with the message when the paginated message closes will result in a DiscordAPIError
-		if (this.response !== null && isAnyInteraction(this.response) && this.response.isMessageComponent())
+		// Ensure no race condition can occur where interacting with the message when the paginated message closes would otherwise result in a DiscordAPIError
+		if (this.response !== null && isAnyInteraction(this.response) && this.response.isMessageComponent()) {
 			this.response.message = await this.response.fetchReply();
+		}
 
 		// Remove all listeners from the collector:
 		this.collector?.removeAllListeners();

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1142,7 +1142,11 @@ export class PaginatedMessage {
 	 * Handles the `end` event from the collector.
 	 * @param reason The reason for which the collector was ended.
 	 */
-	protected handleEnd(_: Collection<Snowflake, ButtonInteraction | SelectMenuInteraction>, reason: string): void {
+	protected async handleEnd(_: Collection<Snowflake, ButtonInteraction | SelectMenuInteraction>, reason: string): Promise<void> {
+		// Fix a race condition bug where interacting with the message when the paginated message closes will result in a DiscordAPIError
+		if (this.response !== null && isAnyInteraction(this.response) && this.response.isMessageComponent())
+			this.response.message = await this.response.fetchReply();
+
 		// Remove all listeners from the collector:
 		this.collector?.removeAllListeners();
 


### PR DESCRIPTION
This pull request fixes a bug where the button components won't get removed due to a race condition error: `DiscordAPIError: Interaction has already been acknowledged.`.
This occurs when the user tries to interact with the message when the paginated message is about to close.
You can reproduce this by spam clicking the next/previous buttons on a paginated message.