### PR TITLE
chore: improve subpath check message

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,8 +7,7 @@
 	"main": "dist/index.js",
 	"exports": {
 		"import": "./dist/index.js",
-		"require": "./dist/index.js",
-		"types": "./dist/index.d.ts"
+		"require": "./dist/index.js"
 	},
 	"sideEffects": false,
 	"homepage": "https://github.com/sapphiredev/utilities/tree/main/packages/eslint-config",

--- a/packages/eslint-config/tsup.config.ts
+++ b/packages/eslint-config/tsup.config.ts
@@ -1,3 +1,3 @@
 import { createTsupConfig } from '../../scripts/tsup.config';
 
-export default createTsupConfig({ format: ['cjs'], sourcemap: false });
+export default createTsupConfig({ format: ['cjs'], sourcemap: false, dts: false });

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -7,8 +7,7 @@
 	"main": "dist/index.js",
 	"exports": {
 		"import": "./dist/index.js",
-		"require": "./dist/index.js",
-		"types": "./dist/index.d.ts"
+		"require": "./dist/index.js"
 	},
 	"sideEffects": false,
 	"homepage": "https://github.com/sapphiredev/utilities/tree/main/packages/prettier-config",

--- a/packages/prettier-config/tsup.config.ts
+++ b/packages/prettier-config/tsup.config.ts
@@ -1,3 +1,3 @@
 import { createTsupConfig } from '../../scripts/tsup.config';
 
-export default createTsupConfig({ format: ['cjs'], sourcemap: false });
+export default createTsupConfig({ format: ['cjs'], sourcemap: false, dts: false });

--- a/scripts/subpath-updater.mjs
+++ b/scripts/subpath-updater.mjs
@@ -1,4 +1,4 @@
-import { green, red } from 'colorette';
+import { green, red, bold } from 'colorette';
 import { writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { format } from 'prettier';
@@ -76,7 +76,7 @@ if (oldPackageJSON === newPackageJSON) {
 }
 
 if (check) {
-	console.error(red(`The package.json file for ${packageName} is not up to date!`));
+	console.error(red(`The package.json file for ${packageName} is not up to date! Run ${green(bold('yarn check-subpath'))} to update it.`));
 	process.exit(1);
 }
 


### PR DESCRIPTION
This pr also removes `dts` files from eslint and prettier config.

I tried to use [--silent](https://github.com/egoist/tsup/search?q=silent) flag for the `dependsOn` builds to hide some logs but idk how can I pass the flags to the build script from `dependsOn`