### PR TITLE
refactor(duration): reuse Time enum

### DIFF
--- a/packages/duration/tests/lib/DurationFormatter.test.ts
+++ b/packages/duration/tests/lib/DurationFormatter.test.ts
@@ -1,10 +1,4 @@
-import { DurationFormatter } from '../../src';
-
-enum Time {
-	Minute = 1000 * 60,
-	Hour = 1000 * 60 * 60,
-	Day = 1000 * 60 * 60 * 24
-}
+import { DurationFormatter, Time } from '../../src';
 
 const formatter = new DurationFormatter();
 


### PR DESCRIPTION
The Time enum is already exported in `constants.ts`. It's worth noting that `/timestamp` also exports the same enum, but I think it would be a bit overkill to create another package just to share one small enum. It does bring up the question of whether the packages usages should copy and paste the same `Time` documentation?