### PR TITLE
fix(discord-utilities): fix nitro upload limit

### DIFF
--- a/packages/discord-utilities/src/lib/limits.ts
+++ b/packages/discord-utilities/src/lib/limits.ts
@@ -250,9 +250,9 @@ export const MessageLimits = {
 
 	/**
 	 * Maximum upload size for a nitro user, in any guild or in DMs.
-	 * Size is in bytes, and correspond to 10MB.
+	 * Size is in bytes, and correspond to 500MB.
 	 */
-	MaximumNitroUploadSize: 100_000_000,
+	MaximumNitroUploadSize: 5_000_000_000,
 
 	/**
 	 * Maximum upload size for a free user for all different boost levels available in a guild.


### PR DESCRIPTION
This PR updates the `MaxNitroUploadLimit` property in the `discord-utilities` package to the new limit.