### PR TITLE
fix(snowflake): TwitterSnowflake using incorrect epoch

### DIFF
--- a/packages/snowflake/src/lib/TwitterSnowflake.ts
+++ b/packages/snowflake/src/lib/TwitterSnowflake.ts
@@ -3,6 +3,6 @@ import { Snowflake } from './Snowflake';
 /**
  * A class for parsing snowflake ids using Twitter's snowflake epoch
  *
- * Which is 2006-03-21 at 20:50:14.000 UTC+0, the time and date of the first tweet ever made {@linkplain https://twitter.com/jack/status/20}
+ * Which is 2010-11-04 at 20:42:54.657 UTC+0, found in the archived snowflake repository {@linkplain https://github.com/twitter-archive/snowflake/blob/b3f6a3c6ca8e1b6847baa6ff42bf72201e2c2231/src/main/scala/com/twitter/service/snowflake/IdWorker.scala#L25}
  */
-export const TwitterSnowflake = new Snowflake(1142974214000n);
+export const TwitterSnowflake = new Snowflake(1288834974657n);

--- a/packages/snowflake/src/lib/TwitterSnowflake.ts
+++ b/packages/snowflake/src/lib/TwitterSnowflake.ts
@@ -3,6 +3,6 @@ import { Snowflake } from './Snowflake';
 /**
  * A class for parsing snowflake ids using Twitter's snowflake epoch
  *
- * Which is 2010-11-04 at 20:42:54.657 UTC+0, found in the archived snowflake repository {@linkplain https://github.com/twitter-archive/snowflake/blob/b3f6a3c6ca8e1b6847baa6ff42bf72201e2c2231/src/main/scala/com/twitter/service/snowflake/IdWorker.scala#L25}
+ * Which is 2010-11-04 at 01:42:54.657 UTC+0, found in the archived snowflake repository {@linkplain https://github.com/twitter-archive/snowflake/blob/b3f6a3c6ca8e1b6847baa6ff42bf72201e2c2231/src/main/scala/com/twitter/service/snowflake/IdWorker.scala#L25}
  */
 export const TwitterSnowflake = new Snowflake(1288834974657n);

--- a/packages/snowflake/tests/lib/TwitterSnowflake.test.ts
+++ b/packages/snowflake/tests/lib/TwitterSnowflake.test.ts
@@ -12,7 +12,7 @@ describe('Twitter Snowflakes', () => {
 
 	describe('Generate', () => {
 		test('GIVEN basic code THEN generates snowflake', () => {
-			const testId = '1823945883910148096';
+			const testId = '1212161512043450368';
 			const snow = TwitterSnowflake.generate();
 
 			expect(snow.toString()).toBe(testId);
@@ -25,11 +25,11 @@ describe('Twitter Snowflakes', () => {
 
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 1823945883910279168n,
-				timestamp: 1577836800000n,
+				timestamp: 1723697560657n,
 				workerId: 1n,
 				processId: 1n,
 				increment: 0n,
-				epoch: 1142974214000n
+				epoch: 1288834974657n
 			});
 		});
 
@@ -38,11 +38,11 @@ describe('Twitter Snowflakes', () => {
 
 			expect(flake).toStrictEqual<DeconstructedSnowflake>({
 				id: 1823945883910279168n,
-				timestamp: 1577836800000n,
+				timestamp: 1723697560657n,
 				workerId: 1n,
 				processId: 1n,
 				increment: 0n,
-				epoch: 1142974214000n
+				epoch: 1288834974657n
 			});
 		});
 	});


### PR DESCRIPTION
Partially fixes #521 by updating the epoch to be `1288834974657`, found [here](https://github.com/twitter-archive/snowflake/blob/b3f6a3c6ca8e1b6847baa6ff42bf72201e2c2231/src/main/scala/com/twitter/service/snowflake/IdWorker.scala#L25) in twitter's archived snowflakes repository

The rest of the issue is deciding what to do (if anything) about non-snowflake tweet ids. Since TwitterSnowflake is deliberately focused on twitter, I'd expect them to be rejected, since they're just numbers, not snowflakes, and would return mismatched data vses. twitter if ever deconstructed.

oduwsdl/tweetedat uses [this](https://github.com/oduwsdl/tweetedat/blob/eae40b65ac99a05b596e75ac7ed015ee6134ab82/index.html#L2500-L2503) check to filter out non-snowflakes, but I don't know how to verify if that's correct, nor do I know how it should be implemented.