### PR TITLE
fix(discord.js-utilities): added null checks for permission checks

### DIFF
--- a/packages/discord.js-utilities/src/lib/utilities.ts
+++ b/packages/discord.js-utilities/src/lib/utilities.ts
@@ -107,5 +107,15 @@ export function canJoinVoiceChannel(channel: VoiceBasedChannel | Nullish): boole
 }
 
 function canDoUtility(channel: ChannelTypes, permissionsToPass: Permissions) {
-	return isGuildBasedChannel(channel) ? channel.permissionsFor(channel.guild.me!)!.has(permissionsToPass) : true;
+	if (!isGuildBasedChannel(channel)) {
+		return true;
+	}
+
+	const { me } = channel.guild;
+	if (!me) return false;
+
+	const permissionsFor = channel.permissionsFor(me);
+	if (!permissionsFor) return false;
+
+	return permissionsFor.has(permissionsToPass);
 }


### PR DESCRIPTION
This resolves a bug in the permission functions that is caused by a bot receiving a message in an unsupported channel, which currently includes forum channels until Sapphire supports DJS v14.