### PR TITLE
feat(snowflake): added `Snowflake.compare`

### DIFF
--- a/packages/snowflake/src/lib/Snowflake.ts
+++ b/packages/snowflake/src/lib/Snowflake.ts
@@ -106,6 +106,29 @@ export class Snowflake {
 	public timestampFrom(id: string | bigint): number {
 		return Number((BigInt(id) >> 22n) + this.#epoch);
 	}
+
+	/**
+	 * Returns a number indicating whether a reference snowflake comes before, or after, or is same as the given
+	 * snowflake in sort order.
+	 * @param a The first snowflake to compare.
+	 * @param b The second snowflake to compare.
+	 * @returns `-1` if `a` is older than `b`, `0` if `a` and `b` are equals, `1` if `a` is newer than `b`.
+	 * @example
+	 * ```typescript
+	 * const ids = ['737141877803057244', '1056191128120082432', '254360814063058944'];
+	 * console.log(ids.sort(a, b) => Snowflake.compare(a, b));
+	 * // → ['254360814063058944', '737141877803057244', '1056191128120082432'];
+	 * ```
+	 */
+	public static compare(a: string | bigint, b: string | bigint): -1 | 0 | 1 {
+		if (typeof a === 'bigint' || typeof b === 'bigint') {
+			if (typeof a === 'string') a = BigInt(a);
+			else if (typeof b === 'string') b = BigInt(b);
+			return a === b ? 0 : a < b ? -1 : 1;
+		}
+
+		return a === b ? 0 : a.length < b.length ? -1 : a.length > b.length ? 1 : a < b ? -1 : 1;
+	}
 }
 
 /**

--- a/packages/snowflake/src/lib/Snowflake.ts
+++ b/packages/snowflake/src/lib/Snowflake.ts
@@ -113,11 +113,17 @@ export class Snowflake {
 	 * @param a The first snowflake to compare.
 	 * @param b The second snowflake to compare.
 	 * @returns `-1` if `a` is older than `b`, `0` if `a` and `b` are equals, `1` if `a` is newer than `b`.
-	 * @example
+	 * @example Sort snowflakes in ascending order
 	 * ```typescript
 	 * const ids = ['737141877803057244', '1056191128120082432', '254360814063058944'];
-	 * console.log(ids.sort(a, b) => Snowflake.compare(a, b));
+	 * console.log(ids.sort((a, b) => Snowflake.compare(a, b)));
 	 * // → ['254360814063058944', '737141877803057244', '1056191128120082432'];
+	 * ```
+	 * @example Sort snowflakes in descending order
+	 * ```typescript
+	 * const ids = ['737141877803057244', '1056191128120082432', '254360814063058944'];
+	 * console.log(ids.sort((a, b) => -Snowflake.compare(a, b)));
+	 * // → ['1056191128120082432', '737141877803057244', '254360814063058944'];
 	 * ```
 	 */
 	public static compare(a: string | bigint, b: string | bigint): -1 | 0 | 1 {

--- a/packages/snowflake/tests/lib/Snowflake.test.ts
+++ b/packages/snowflake/tests/lib/Snowflake.test.ts
@@ -181,4 +181,21 @@ describe('Snowflake', () => {
 			});
 		});
 	});
+
+	describe.each([
+		[String, String],
+		[String, BigInt],
+		[BigInt, String],
+		[BigInt, BigInt]
+	])('Compare', (ctorA, ctorB) => {
+		test.each([
+			[ctorA(737141877803057244n), ctorB(254360814063058944n), 1],
+			[ctorA(1737141877803057244n), ctorB(254360814063058944n), 1],
+			[ctorA(737141877803057244n), ctorB(737141877803057244n), 0],
+			[ctorA(254360814063058944n), ctorB(737141877803057244n), -1],
+			[ctorA(254360814063058944n), ctorB(1737141877803057244n), -1]
+		])('GIVEN %o and %o THEN returns %d', (a, b, expected) => {
+			expect(Snowflake.compare(a, b)).toBe(expected);
+		});
+	});
 });


### PR DESCRIPTION
Useful for sorting structures by snowflakes, also does string length comparison when both values are strings to avoid false positives, as `a < b` (as both strings) will do an alphabetical order sort rather than a number sort.
