### PR TITLE
fix(utilities/paginatedmessages): using random color causes an error

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
@@ -1,6 +1,6 @@
-import { isFunction } from "@sapphire/utilities";
-import { EmbedBuilder, type EmbedData } from "discord.js";
-import { PaginatedMessage } from "./PaginatedMessage";
+import { isFunction } from '@sapphire/utilities';
+import { EmbedBuilder, type EmbedData } from 'discord.js';
+import { PaginatedMessage } from './PaginatedMessage';
 
 /**
  * This is a utility of {@link PaginatedMessage}, except it exclusively adds pagination inside a field of an embed.
@@ -29,167 +29,158 @@ import { PaginatedMessage } from "./PaginatedMessage";
  * ```
  */
 export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
-  private embedTemplate: EmbedBuilder = new EmbedBuilder();
-  private totalPages = 0;
-  private items: T[] = [];
-  private itemsPerPage = 10;
-  private fieldTitle = "";
+	private embedTemplate: EmbedBuilder = new EmbedBuilder();
+	private totalPages = 0;
+	private items: T[] = [];
+	private itemsPerPage = 10;
+	private fieldTitle = '';
 
-  /**
-   * Set the items to paginate.
-   * @param items The pages to set
-   */
-  public setItems(items: T[]) {
-    this.items = items;
-    return this;
-  }
+	/**
+	 * Set the items to paginate.
+	 * @param items The pages to set
+	 */
+	public setItems(items: T[]) {
+		this.items = items;
+		return this;
+	}
 
-  /**
-   * Set the title of the embed field that will be used to paginate the items.
-   * @param title The field title
-   */
-  public setTitleField(title: string) {
-    this.fieldTitle = title;
-    return this;
-  }
+	/**
+	 * Set the title of the embed field that will be used to paginate the items.
+	 * @param title The field title
+	 */
+	public setTitleField(title: string) {
+		this.fieldTitle = title;
+		return this;
+	}
 
-  /**
-   * Sets the amount of items that should be shown per page.
-   * @param itemsPerPage The number of items
-   */
-  public setItemsPerPage(itemsPerPage: number) {
-    this.itemsPerPage = itemsPerPage;
-    return this;
-  }
+	/**
+	 * Sets the amount of items that should be shown per page.
+	 * @param itemsPerPage The number of items
+	 */
+	public setItemsPerPage(itemsPerPage: number) {
+		this.itemsPerPage = itemsPerPage;
+		return this;
+	}
 
-  /**
-   * Sets the template to be used to display the embed fields as pages. This template can either be set from a template {@link EmbedBuilder} instance or an object with embed options.
-   *
-   * @param template EmbedBuilder
-   *
-   * @example
-   * ```typescript
-   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-   * import { EmbedBuilder } from 'discord.js';
-   *
-   * new PaginatedFieldMessageEmbed().setTemplate(new EmbedBuilder().setTitle('Test pager embed')).make().run(message);
-   * ```
-   *
-   * @example
-   * ```typescript
-   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-   *
-   * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message);
-   * ```
-   */
-  public setTemplate(
-    template: EmbedData | EmbedBuilder | ((embed: EmbedBuilder) => EmbedBuilder)
-  ) {
-    this.embedTemplate = this.resolveTemplate(template);
-    return this;
-  }
+	/**
+	 * Sets the template to be used to display the embed fields as pages. This template can either be set from a template {@link EmbedBuilder} instance or an object with embed options.
+	 *
+	 * @param template EmbedBuilder
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+	 * import { EmbedBuilder } from 'discord.js';
+	 *
+	 * new PaginatedFieldMessageEmbed().setTemplate(new EmbedBuilder().setTitle('Test pager embed')).make().run(message);
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+	 *
+	 * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message);
+	 * ```
+	 */
+	public setTemplate(template: EmbedData | EmbedBuilder | ((embed: EmbedBuilder) => EmbedBuilder)) {
+		this.embedTemplate = this.resolveTemplate(template);
+		return this;
+	}
 
-  /**
-   * Sets a format callback that will be mapped to each embed field in the array of items when the embed is paginated. This should convert each item to a format that is either text itself or can be serialized as text.
-   *
-   * @example
-   * ```typescript
-   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-   *
-   * new PaginatedFieldMessageEmbed()
-   *    .setTitleField('Test field')
-   *    .setTemplate({ embed })
-   *    .setItems([
-   *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
-   *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
-   *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
-   *     ])
-   *    .formatItems((item) => `${item.title}\n${item.value}`)
-   *    .make()
-   *    .run(message);
-   * ```
-   * @param formatter The formatter callback to be applied to each embed item
-   */
-  public formatItems(formatter: (item: T, index: number, array: T[]) => any) {
-    this.items = this.items.map(formatter);
-    return this;
-  }
+	/**
+	 * Sets a format callback that will be mapped to each embed field in the array of items when the embed is paginated. This should convert each item to a format that is either text itself or can be serialized as text.
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+	 *
+	 * new PaginatedFieldMessageEmbed()
+	 *    .setTitleField('Test field')
+	 *    .setTemplate({ embed })
+	 *    .setItems([
+	 *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
+	 *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
+	 *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
+	 *     ])
+	 *    .formatItems((item) => `${item.title}\n${item.value}`)
+	 *    .make()
+	 *    .run(message);
+	 * ```
+	 * @param formatter The formatter callback to be applied to each embed item
+	 */
+	public formatItems(formatter: (item: T, index: number, array: T[]) => any) {
+		this.items = this.items.map(formatter);
+		return this;
+	}
 
-  /**
-   * Build the pages of the given array.
-   *
-   * You must call the {@link PaginatedFieldMessageEmbed.make} and {@link PaginatedFieldMessageEmbed.run} methods last, in that order, for the pagination to work.
-   *
-   * @example
-   * ```typescript
-   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-   *
-   * new PaginatedFieldMessageEmbed()
-   *    .setTitleField('Test field')
-   *    .setTemplate({ embed })
-   *    .setItems([
-   *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
-   *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
-   *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
-   *     ])
-   *    .formatItems((item) => `${item.title}\n${item.value}`)
-   *    .make()
-   *    .run(message);
-   * ```
-   */
-  public make() {
-    if (!this.fieldTitle.length)
-      throw new Error("The title of the field to format must have a value.");
-    if (!this.items.length) throw new Error("The items array is empty.");
-    if (this.items.some((x) => !x))
-      throw new Error("The format of the array items is incorrect.");
+	/**
+	 * Build the pages of the given array.
+	 *
+	 * You must call the {@link PaginatedFieldMessageEmbed.make} and {@link PaginatedFieldMessageEmbed.run} methods last, in that order, for the pagination to work.
+	 *
+	 * @example
+	 * ```typescript
+	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+	 *
+	 * new PaginatedFieldMessageEmbed()
+	 *    .setTitleField('Test field')
+	 *    .setTemplate({ embed })
+	 *    .setItems([
+	 *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
+	 *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
+	 *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
+	 *     ])
+	 *    .formatItems((item) => `${item.title}\n${item.value}`)
+	 *    .make()
+	 *    .run(message);
+	 * ```
+	 */
+	public make() {
+		if (!this.fieldTitle.length) throw new Error('The title of the field to format must have a value.');
+		if (!this.items.length) throw new Error('The items array is empty.');
+		if (this.items.some((x) => !x)) throw new Error('The format of the array items is incorrect.');
 
-    this.totalPages = Math.ceil(this.items.length / this.itemsPerPage);
-    this.generatePages();
-    return this;
-  }
+		this.totalPages = Math.ceil(this.items.length / this.itemsPerPage);
+		this.generatePages();
+		return this;
+	}
 
-  private generatePages() {
-    const template =
-      this.embedTemplate instanceof EmbedBuilder
-        ? this.embedTemplate.toJSON()
-        : this.embedTemplate;
-    for (let i = 0; i < this.totalPages; i++) {
-      const clonedTemplate = new EmbedBuilder(template);
-      const fieldsClone = this.embedTemplate.data.fields ?? [];
-      clonedTemplate.data.fields = [];
+	private generatePages() {
+		const template = this.embedTemplate instanceof EmbedBuilder ? this.embedTemplate.toJSON() : this.embedTemplate;
+		for (let i = 0; i < this.totalPages; i++) {
+			const clonedTemplate = new EmbedBuilder(template);
+			const fieldsClone = this.embedTemplate.data.fields ?? [];
+			clonedTemplate.data.fields = [];
 
-      const data = this.paginateArray(this.items, i, this.itemsPerPage);
-      this.addPage({
-        embeds: [
-          clonedTemplate
-            .addFields({
-              name: this.fieldTitle,
-              value: data.join("\n"),
-              inline: false,
-            })
-            .addFields(fieldsClone),
-        ],
-      });
-    }
-  }
+			const data = this.paginateArray(this.items, i, this.itemsPerPage);
+			this.addPage({
+				embeds: [
+					clonedTemplate
+						.addFields({
+							name: this.fieldTitle,
+							value: data.join('\n'),
+							inline: false
+						})
+						.addFields(fieldsClone)
+				]
+			});
+		}
+	}
 
-  private paginateArray(items: T[], currentPage: number, perPageItems: number) {
-    const offset = currentPage * perPageItems;
-    return items.slice(offset, offset + perPageItems);
-  }
+	private paginateArray(items: T[], currentPage: number, perPageItems: number) {
+		const offset = currentPage * perPageItems;
+		return items.slice(offset, offset + perPageItems);
+	}
 
-  private resolveTemplate(
-    template: EmbedBuilder | EmbedData | ((embed: EmbedBuilder) => EmbedBuilder)
-  ) {
-    if (template instanceof EmbedBuilder) {
-      return template;
-    }
+	private resolveTemplate(template: EmbedBuilder | EmbedData | ((embed: EmbedBuilder) => EmbedBuilder)) {
+		if (template instanceof EmbedBuilder) {
+			return template;
+		}
 
-    if (isFunction(template)) {
-      return template(new EmbedBuilder());
-    }
+		if (isFunction(template)) {
+			return template(new EmbedBuilder());
+		}
 
-    return new EmbedBuilder(template);
-  }
+		return new EmbedBuilder(template);
+	}
 }

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
@@ -1,6 +1,6 @@
-import { isFunction } from '@sapphire/utilities';
-import { EmbedBuilder, type EmbedData } from 'discord.js';
-import { PaginatedMessage } from './PaginatedMessage';
+import { isFunction } from "@sapphire/utilities";
+import { EmbedBuilder, type EmbedData } from "discord.js";
+import { PaginatedMessage } from "./PaginatedMessage";
 
 /**
  * This is a utility of {@link PaginatedMessage}, except it exclusively adds pagination inside a field of an embed.
@@ -29,152 +29,167 @@ import { PaginatedMessage } from './PaginatedMessage';
  * ```
  */
 export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
-	private embedTemplate: EmbedBuilder = new EmbedBuilder();
-	private totalPages = 0;
-	private items: T[] = [];
-	private itemsPerPage = 10;
-	private fieldTitle = '';
+  private embedTemplate: EmbedBuilder = new EmbedBuilder();
+  private totalPages = 0;
+  private items: T[] = [];
+  private itemsPerPage = 10;
+  private fieldTitle = "";
 
-	/**
-	 * Set the items to paginate.
-	 * @param items The pages to set
-	 */
-	public setItems(items: T[]) {
-		this.items = items;
-		return this;
-	}
+  /**
+   * Set the items to paginate.
+   * @param items The pages to set
+   */
+  public setItems(items: T[]) {
+    this.items = items;
+    return this;
+  }
 
-	/**
-	 * Set the title of the embed field that will be used to paginate the items.
-	 * @param title The field title
-	 */
-	public setTitleField(title: string) {
-		this.fieldTitle = title;
-		return this;
-	}
+  /**
+   * Set the title of the embed field that will be used to paginate the items.
+   * @param title The field title
+   */
+  public setTitleField(title: string) {
+    this.fieldTitle = title;
+    return this;
+  }
 
-	/**
-	 * Sets the amount of items that should be shown per page.
-	 * @param itemsPerPage The number of items
-	 */
-	public setItemsPerPage(itemsPerPage: number) {
-		this.itemsPerPage = itemsPerPage;
-		return this;
-	}
+  /**
+   * Sets the amount of items that should be shown per page.
+   * @param itemsPerPage The number of items
+   */
+  public setItemsPerPage(itemsPerPage: number) {
+    this.itemsPerPage = itemsPerPage;
+    return this;
+  }
 
-	/**
-	 * Sets the template to be used to display the embed fields as pages. This template can either be set from a template {@link EmbedBuilder} instance or an object with embed options.
-	 *
-	 * @param template EmbedBuilder
-	 *
-	 * @example
-	 * ```typescript
-	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-	 * import { EmbedBuilder } from 'discord.js';
-	 *
-	 * new PaginatedFieldMessageEmbed().setTemplate(new EmbedBuilder().setTitle('Test pager embed')).make().run(message);
-	 * ```
-	 *
-	 * @example
-	 * ```typescript
-	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-	 *
-	 * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message);
-	 * ```
-	 */
-	public setTemplate(template: EmbedData | EmbedBuilder | ((embed: EmbedBuilder) => EmbedBuilder)) {
-		this.embedTemplate = this.resolveTemplate(template);
-		return this;
-	}
+  /**
+   * Sets the template to be used to display the embed fields as pages. This template can either be set from a template {@link EmbedBuilder} instance or an object with embed options.
+   *
+   * @param template EmbedBuilder
+   *
+   * @example
+   * ```typescript
+   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+   * import { EmbedBuilder } from 'discord.js';
+   *
+   * new PaginatedFieldMessageEmbed().setTemplate(new EmbedBuilder().setTitle('Test pager embed')).make().run(message);
+   * ```
+   *
+   * @example
+   * ```typescript
+   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+   *
+   * new PaginatedFieldMessageEmbed().setTemplate({ title: 'Test pager embed' }).make().run(message);
+   * ```
+   */
+  public setTemplate(
+    template: EmbedData | EmbedBuilder | ((embed: EmbedBuilder) => EmbedBuilder)
+  ) {
+    this.embedTemplate = this.resolveTemplate(template);
+    return this;
+  }
 
-	/**
-	 * Sets a format callback that will be mapped to each embed field in the array of items when the embed is paginated. This should convert each item to a format that is either text itself or can be serialized as text.
-	 *
-	 * @example
-	 * ```typescript
-	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-	 *
-	 * new PaginatedFieldMessageEmbed()
-	 *    .setTitleField('Test field')
-	 *    .setTemplate({ embed })
-	 *    .setItems([
-	 *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
-	 *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
-	 *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
-	 *     ])
-	 *    .formatItems((item) => `${item.title}\n${item.value}`)
-	 *    .make()
-	 *    .run(message);
-	 * ```
-	 * @param formatter The formatter callback to be applied to each embed item
-	 */
-	public formatItems(formatter: (item: T, index: number, array: T[]) => any) {
-		this.items = this.items.map(formatter);
-		return this;
-	}
+  /**
+   * Sets a format callback that will be mapped to each embed field in the array of items when the embed is paginated. This should convert each item to a format that is either text itself or can be serialized as text.
+   *
+   * @example
+   * ```typescript
+   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+   *
+   * new PaginatedFieldMessageEmbed()
+   *    .setTitleField('Test field')
+   *    .setTemplate({ embed })
+   *    .setItems([
+   *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
+   *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
+   *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
+   *     ])
+   *    .formatItems((item) => `${item.title}\n${item.value}`)
+   *    .make()
+   *    .run(message);
+   * ```
+   * @param formatter The formatter callback to be applied to each embed item
+   */
+  public formatItems(formatter: (item: T, index: number, array: T[]) => any) {
+    this.items = this.items.map(formatter);
+    return this;
+  }
 
-	/**
-	 * Build the pages of the given array.
-	 *
-	 * You must call the {@link PaginatedFieldMessageEmbed.make} and {@link PaginatedFieldMessageEmbed.run} methods last, in that order, for the pagination to work.
-	 *
-	 * @example
-	 * ```typescript
-	 * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
-	 *
-	 * new PaginatedFieldMessageEmbed()
-	 *    .setTitleField('Test field')
-	 *    .setTemplate({ embed })
-	 *    .setItems([
-	 *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
-	 *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
-	 *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
-	 *     ])
-	 *    .formatItems((item) => `${item.title}\n${item.value}`)
-	 *    .make()
-	 *    .run(message);
-	 * ```
-	 */
-	public make() {
-		if (!this.fieldTitle.length) throw new Error('The title of the field to format must have a value.');
-		if (!this.items.length) throw new Error('The items array is empty.');
-		if (this.items.some((x) => !x)) throw new Error('The format of the array items is incorrect.');
+  /**
+   * Build the pages of the given array.
+   *
+   * You must call the {@link PaginatedFieldMessageEmbed.make} and {@link PaginatedFieldMessageEmbed.run} methods last, in that order, for the pagination to work.
+   *
+   * @example
+   * ```typescript
+   * import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+   *
+   * new PaginatedFieldMessageEmbed()
+   *    .setTitleField('Test field')
+   *    .setTemplate({ embed })
+   *    .setItems([
+   *       { title: 'Sapphire Framework', value: 'discord.js Framework' },
+   *       { title: 'Sapphire Framework 2', value: 'discord.js Framework 2' },
+   *       { title: 'Sapphire Framework 3', value: 'discord.js Framework 3' }
+   *     ])
+   *    .formatItems((item) => `${item.title}\n${item.value}`)
+   *    .make()
+   *    .run(message);
+   * ```
+   */
+  public make() {
+    if (!this.fieldTitle.length)
+      throw new Error("The title of the field to format must have a value.");
+    if (!this.items.length) throw new Error("The items array is empty.");
+    if (this.items.some((x) => !x))
+      throw new Error("The format of the array items is incorrect.");
 
-		this.totalPages = Math.ceil(this.items.length / this.itemsPerPage);
-		this.generatePages();
-		return this;
-	}
+    this.totalPages = Math.ceil(this.items.length / this.itemsPerPage);
+    this.generatePages();
+    return this;
+  }
 
-	private generatePages() {
-		const template = this.embedTemplate instanceof EmbedBuilder ? this.embedTemplate.toJSON() : this.embedTemplate;
-		for (let i = 0; i < this.totalPages; i++) {
-			const clonedTemplate = new EmbedBuilder(template);
-			const fieldsClone = this.embedTemplate.data.fields ?? [];
-			clonedTemplate.data.fields = [];
+  private generatePages() {
+    const template =
+      this.embedTemplate instanceof EmbedBuilder
+        ? this.embedTemplate.toJSON()
+        : this.embedTemplate;
+    for (let i = 0; i < this.totalPages; i++) {
+      const clonedTemplate = new EmbedBuilder(template);
+      const fieldsClone = this.embedTemplate.data.fields ?? [];
+      clonedTemplate.data.fields = [];
 
-			if (!clonedTemplate.data.color) clonedTemplate.setColor('Random');
+      const data = this.paginateArray(this.items, i, this.itemsPerPage);
+      this.addPage({
+        embeds: [
+          clonedTemplate
+            .addFields({
+              name: this.fieldTitle,
+              value: data.join("\n"),
+              inline: false,
+            })
+            .addFields(fieldsClone),
+        ],
+      });
+    }
+  }
 
-			const data = this.paginateArray(this.items, i, this.itemsPerPage);
-			this.addPage({
-				embeds: [clonedTemplate.addFields({ name: this.fieldTitle, value: data.join('\n'), inline: false }).addFields(fieldsClone)]
-			});
-		}
-	}
+  private paginateArray(items: T[], currentPage: number, perPageItems: number) {
+    const offset = currentPage * perPageItems;
+    return items.slice(offset, offset + perPageItems);
+  }
 
-	private paginateArray(items: T[], currentPage: number, perPageItems: number) {
-		const offset = currentPage * perPageItems;
-		return items.slice(offset, offset + perPageItems);
-	}
+  private resolveTemplate(
+    template: EmbedBuilder | EmbedData | ((embed: EmbedBuilder) => EmbedBuilder)
+  ) {
+    if (template instanceof EmbedBuilder) {
+      return template;
+    }
 
-	private resolveTemplate(template: EmbedBuilder | EmbedData | ((embed: EmbedBuilder) => EmbedBuilder)) {
-		if (template instanceof EmbedBuilder) {
-			return template;
-		}
+    if (isFunction(template)) {
+      return template(new EmbedBuilder());
+    }
 
-		if (isFunction(template)) {
-			return template(new EmbedBuilder());
-		}
-
-		return new EmbedBuilder(template);
-	}
+    return new EmbedBuilder(template);
+  }
 }

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
@@ -120,8 +120,6 @@ export class PaginatedMessageEmbedFields extends PaginatedMessage {
 			const fieldsClone = this.embedTemplate.data.fields ?? [];
 			clonedTemplate.data.fields = [];
 
-			if (!clonedTemplate.data.color) clonedTemplate.setColor('Random');
-
 			const data = this.paginateArray(this.items, i, this.itemsPerPage - fieldsClone.length);
 			this.addPage({
 				embeds: [clonedTemplate.addFields(...data, ...fieldsClone)]


### PR DESCRIPTION
Error:
```
DiscordAPIError[50035]: Invalid Form Body
embeds[0].color[NUMBER_TYPE_COERCE]: Value "#ffae35" is not int.
    at SequentialHandler.runRequest (/app/node_modules/.pnpm/@discordjs+rest@1.5.0/node_modules/@discordjs/rest/src/lib/handlers/SequentialHandler.ts:498:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at SequentialHandler.queueRequest (/app/node_modules/.pnpm/@discordjs+rest@1.5.0/node_modules/@discordjs/rest/src/lib/handlers/SequentialHandler.ts:198:11)
    at REST.request (/app/node_modules/.pnpm/@discordjs+rest@1.5.0/node_modules/@discordjs/rest/src/lib/REST.ts:343:20)
    at async InteractionWebhook.editMessage (/app/node_modules/.pnpm/discord.js@14.7.1/node_modules/discord.js/src/structures/Webhook.js:338:15)
    at async ChatInputCommandInteraction.editReply (/app/node_modules/.pnpm/discord.js@14.7.1/node_modules/discord.js/src/structures/interfaces/InteractionResponses.js:158:17)
    at PaginatedMessageEmbedFields.setUpMessage (/app/node_modules/.pnpm/@sapphire+discord.js-utilities@6.0.1/node_modules/@sapphire/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts:967:25)
    at PaginatedMessageEmbedFields.run (/app/node_modules/.pnpm/@sapphire+discord.js-utilities@6.0.1/node_modules/@sapphire/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts:859:25)
    at <anonymous> (/app/node_modules/.pnpm/@sapphire+plugin-subcommands@4.0.0/node_modules/@sapphire/plugin-subcommands/src/lib/Subcommand.ts:322:15)
    at Object.fromAsync (/app/node_modules/.pnpm/@sapphire+result@2.6.0/node_modules/@sapphire/result/src/lib/Result.ts:55:2)
```