### PR TITLE
refactor(ratelimits): remove dependency on `@sapphire/timer-manager`

### DIFF
--- a/packages/ratelimits/package.json
+++ b/packages/ratelimits/package.json
@@ -55,9 +55,6 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"dependencies": {
-		"@sapphire/timer-manager": "workspace:^"
-	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.0.0",
 		"@vitest/coverage-c8": "^0.29.2",

--- a/packages/ratelimits/src/lib/RateLimitManager.ts
+++ b/packages/ratelimits/src/lib/RateLimitManager.ts
@@ -1,4 +1,3 @@
-import { TimerManager } from '@sapphire/timer-manager';
 import { RateLimit } from './RateLimit';
 
 export class RateLimitManager<K = string> extends Map<K, RateLimit<K>> {
@@ -52,7 +51,7 @@ export class RateLimitManager<K = string> extends Map<K, RateLimit<K>> {
 	 * @param value The {@link RateLimit} to set
 	 */
 	public override set(id: K, value: RateLimit<K>): this {
-		this.sweepInterval ??= TimerManager.setInterval(this.sweep.bind(this), RateLimitManager.sweepIntervalDuration);
+		this.sweepInterval ??= setInterval(this.sweep.bind(this), RateLimitManager.sweepIntervalDuration);
 		return super.set(id, value);
 	}
 
@@ -64,8 +63,8 @@ export class RateLimitManager<K = string> extends Map<K, RateLimit<K>> {
 			if (value.expired) this.delete(id);
 		}
 
-		if (this.size === 0) {
-			TimerManager.clearInterval(this.sweepInterval!);
+		if (this.size === 0 && this.sweepInterval !== null) {
+			clearInterval(this.sweepInterval);
 			this.sweepInterval = null;
 		}
 	}

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,7 @@
 				"@sapphire/lexure#build",
 				"@sapphire/node-utilities#build",
 				"@sapphire/ratelimits#build",
+				"@sapphire/timer-manager#build",
 				"@sapphire/result#build",
 				"@sapphire/snowflake#build",
 				"@sapphire/timestamp#build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,7 +1089,6 @@ __metadata:
   resolution: "@sapphire/ratelimits@workspace:packages/ratelimits"
   dependencies:
     "@favware/cliff-jumper": ^2.0.0
-    "@sapphire/timer-manager": "workspace:^"
     "@vitest/coverage-c8": ^0.29.2
     tsup: ^6.6.3
     typedoc: ^0.23.26


### PR DESCRIPTION
ref: https://twitter.com/syjalo_/status/1633737653806940161

This ensures that the package is serverless ready where it is not
possible to install Node dependencies.
