### PR TITLE
feat(decorators): update decorators to new ECMAScript proposal

### DIFF
--- a/packages/decorators/src/base-decorators.ts
+++ b/packages/decorators/src/base-decorators.ts
@@ -1,32 +1,58 @@
-import type { NonNullObject } from '@sapphire/utilities';
-import { createMethodDecorator } from './utils';
+import type { Piece } from '@sapphire/framework';
+import type { ClassWithName, EnumerableCacheEntry, EnumerableFieldReturnType, PieceConstructor, SyntheticClassDecoratorReturn } from './types';
+
+const enumerableCache: Map<string, EnumerableCacheEntry[]> = new Map();
 
 /**
- * Decorator that sets the enumerable property of a class field to the desired value.
+ * Decorator that reads {@link enumerableCache} for the decorated class and sets the enumerable property of any fields decorated with {@link Enumerable}.
+ *
+ * Without applying this decorator on the class the field {@link Enumerable} decorators will have no effect!
  * @param value Whether the property should be enumerable or not
  */
-export function Enumerable(value: boolean) {
-	return (target: unknown, key: string) => {
-		Reflect.defineProperty(target as NonNullObject, key, {
-			enumerable: value,
-			set(this: unknown, val: unknown) {
-				Reflect.defineProperty(this as NonNullObject, key, {
-					configurable: true,
-					enumerable: value,
-					value: val,
-					writable: true
+export function Enumerable<Class extends PieceConstructor>(): SyntheticClassDecoratorReturn<Class>;
+/**
+ * Decorator that queues the decorated field for being marked as `enumerable` or not based on the parameter value.
+ * Apply to the class by adding {@link Enumerable} on the class
+ *
+ * Without applying this decorator on the class {@link Enumerable} decorators on the fields will have no effect!
+ *
+ * @param value Whether the property should be enumerable or not
+ */
+export function Enumerable<This, Value>(enumerable: boolean): EnumerableFieldReturnType<This, Value>;
+export function Enumerable<ThisOrClass, Value>(enumerable?: boolean) {
+	if (typeof enumerable === 'boolean') {
+		return (_value: undefined, context: ClassFieldDecoratorContext<ThisOrClass, Value>) =>
+			function replacementField(this: ClassWithName, initialValue: Value): Value {
+				const classFields = enumerableCache.get(this.name);
+
+				if (classFields) {
+					classFields.push({
+						fieldName: context.name,
+						shouldBeEnumerable: enumerable ?? true
+					});
+				} else {
+					enumerableCache.set(this.name, [
+						{
+							fieldName: context.name,
+							shouldBeEnumerable: enumerable ?? true
+						}
+					]);
+				}
+
+				return initialValue;
+			};
+	}
+
+	return (DecoratedClass: PieceConstructor, _context: ClassDecoratorContext) =>
+		function replacementClass(...args: ConstructorParameters<typeof Piece>) {
+			const classInstance = new DecoratedClass(...args);
+
+			for (const cacheEntry of (enumerableCache.get(classInstance.name) ?? []).values()) {
+				Object.defineProperty(classInstance, cacheEntry.fieldName, {
+					enumerable: cacheEntry.shouldBeEnumerable
 				});
 			}
-		});
-	};
-}
 
-/**
- * Decorator that sets the enumerable property of a class method to the desired value.
- * @param value Whether the method should be enumerable or not
- */
-export function EnumerableMethod(value: boolean) {
-	return createMethodDecorator((_target, _propertyKey, descriptor) => {
-		descriptor.enumerable = value;
-	});
+			return classInstance;
+		};
 }

--- a/packages/decorators/src/index.ts
+++ b/packages/decorators/src/index.ts
@@ -1,4 +1,5 @@
 export * from './base-decorators';
 export * from './djs-decorators';
 export * from './piece-decorators';
+export type * from './types';
 export * from './utils';

--- a/packages/decorators/src/types.ts
+++ b/packages/decorators/src/types.ts
@@ -1,0 +1,102 @@
+import type { Container, Piece } from '@sapphire/pieces';
+import type { Ctor } from '@sapphire/utilities';
+
+/**
+ * The function precondition interface.
+ */
+export interface FunctionPrecondition<Args extends unknown[]> {
+	/**
+	 * The arguments passed to the function or class' method.
+	 */
+	(...args: Args): boolean;
+}
+
+/**
+ * The method that is called in `createMethodDecorator` for modifying the source method.
+ */
+export type MethodDecoratorModifier = () => void;
+
+/**
+ * The fallback interface, this is called when the function precondition returns or resolves with a falsy value.
+ */
+export interface FunctionFallback<This, Args extends unknown[], Return = unknown> {
+	/**
+	 * The arguments passed to the function or class' method.
+	 */
+	(this: This, ...args: Args): Return;
+}
+
+/**
+ * A class method that is decorated.
+ */
+export type ClassMethodDecoratorTarget<This, Args extends unknown[], Return> = (this: This, ...args: Args) => Return;
+
+/**
+ * A stricter context for {@link ClassMethodDecoratorContext} that includes {@link ClassMethodDecoratorTarget}
+ */
+export type StrictClassMethodDecoratorContext<This, Args extends unknown[], Return> = ClassMethodDecoratorContext<
+	This,
+	ClassMethodDecoratorTarget<This, Args, Return>
+>;
+
+/**
+ * The return type for class method decorators that is strictly typed
+ */
+export type ClassMethodDecorator<This, Args extends unknown[], Return> = (
+	target: ClassMethodDecoratorTarget<This, Args, Return>,
+	context: StrictClassMethodDecoratorContext<This, Args, Return>
+) => ClassMethodDecoratorTarget<This, Args, Return>;
+
+/**
+ * The cache for enumerable entries for the `Enumerable` decorator.
+ */
+export interface EnumerableCacheEntry {
+	fieldName: string | symbol;
+	shouldBeEnumerable: boolean;
+}
+
+/**
+ * A generic interface for classes that have a `name` property.
+ * This is a stand-in for `typeof Piece` because its other properties are not necessary.
+ */
+export type ClassWithName = Pick<Piece, 'name'>;
+
+/**
+ * The constructor of the {@link Piece} class using {@link Ctor} and {@link ConstructorParameters}
+ */
+export type PieceConstructor = Ctor<ConstructorParameters<typeof Piece>>;
+
+/**
+ * The return type for the `Enumerable` decorator when using on a class field
+ * @param This a reference to the `this` context of the decorated class. This should be added automatically by TypeScript.
+ * @param Value a reference to the current value being decorated. This should be added automatically by TypeScript.
+ */
+export type EnumerableFieldReturnType<This, Value> = (
+	_value: undefined,
+	context: ClassFieldDecoratorContext<This, Value>
+) => (this: ClassWithName, initialValue: Value) => Value;
+
+/**
+ * A synthetic type of a class decorator return value
+ * @param Target The type for the decorated class.
+ * @param Context The type for the *decorator context*.
+ * A context type based on the kind of decoration type, intersected with an object type consisting
+ * of the target's *`name`, `placement`, and `visibility`*.
+ * @param Return The allowed type for the decorator's return value. Note that any decorator may return `void` / `undefined`.
+ * For a class decorator, this will be {@link T}.
+ *
+ */
+export type SyntheticClassDecoratorReturn<Target extends PieceConstructor, Context = ClassDecoratorContext, Return = Target> = (
+	target: Target,
+	context: Context
+) => Return | undefined;
+
+/**
+ * The parameters for the `ApplyOptions` decorator when used with a callback function
+ */
+export interface ApplyOptionsCallbackParameters {
+	/** The {@link Container} of Sapphire */
+	container: Container;
+	/** The context of the current piece */
+	context: Piece.Context;
+}


### PR DESCRIPTION
> **Warning**
> Targets the `feat/typescript-v5` branch but separate for easier reviewing

BREAKING CHANGE: DO NOT attempt to use this version with TypeScript 4.x, it will not work!
BREAKING CHANGE: `EnumerableMethod` is gone, it never really worked anyway
BREAKING CHANGE: `Enumerable` now has to be applied to both fields and classes for it to work
BREAKING CHANGE: Typings have generally overall changed