### PR TITLE
perf(chunk): remove clone

### DIFF
--- a/packages/eslint-config/tests/__snapshots__/eslint.test.ts.snap
+++ b/packages/eslint-config/tests/__snapshots__/eslint.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ESLint Config > should export rules 1`] = `
 {

--- a/packages/prettier-config/tests/__snapshots__/prettier.test.ts.snap
+++ b/packages/prettier-config/tests/__snapshots__/prettier.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Prettier Config > should export rules 1`] = `
 {

--- a/packages/utilities/src/lib/chunk.ts
+++ b/packages/utilities/src/lib/chunk.ts
@@ -7,8 +7,7 @@ export function chunk<T>(array: readonly T[], chunkSize: number): T[][] {
 	if (!Array.isArray(array)) throw new TypeError('entries must be an array.');
 	if (!Number.isInteger(chunkSize)) throw new TypeError('chunkSize must be an integer.');
 	if (chunkSize < 1) throw new RangeError('chunkSize must be 1 or greater.');
-	const clone: T[] = array.slice();
 	const chunks: T[][] = [];
-	while (clone.length) chunks.push(clone.splice(0, chunkSize));
+	for (let i = 0; i < chunkSize; i += chunkSize) chunks.push(array.slice(i, i + chunkSize));
 	return chunks;
 }

--- a/packages/utilities/src/lib/chunk.ts
+++ b/packages/utilities/src/lib/chunk.ts
@@ -8,6 +8,6 @@ export function chunk<T>(array: readonly T[], chunkSize: number): T[][] {
 	if (!Number.isInteger(chunkSize)) throw new TypeError('chunkSize must be an integer.');
 	if (chunkSize < 1) throw new RangeError('chunkSize must be 1 or greater.');
 	const chunks: T[][] = [];
-	for (let i = 0; i < chunkSize; i += chunkSize) chunks.push(array.slice(i, i + chunkSize));
+	for (let i = 0; i < array.length; i += chunkSize) chunks.push(array.slice(i, i + chunkSize));
 	return chunks;
 }


### PR DESCRIPTION
Tested on an array with 21 elements:

| Version |   100,000 |      % | 1,000,000 |      % |
| :-----: | :-------: | :----: | :-------: | :----: |
| Old     | 257.704ms |   100% |    2.163s |   100% |
| New     | 162.308ms | 62.98% |    1.532s | 70.82% |

The updated function also uses half as much memory, as it doesn't clone the array. The performance improvement should be even greater on larger arrays, as removing (or inserting) elements at the start of an array is the slowest array operation.