### PR TITLE
feat(discord.js-utilities): add `JITPaginatedMessage` for per-page action support

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/JITPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/JITPaginatedMessage.ts
@@ -1,0 +1,118 @@
+import { PaginatedMessage } from './PaginatedMessage';
+import { Message, User } from 'discord.js';
+import { isNullish } from '@sapphire/utilities';
+import { actionIsButtonOrMenu, createPartitionedMessageRow } from './utils';
+import type { PaginatedMessageAction, PaginatedMessageComponentUnion } from './PaginatedMessageTypes';
+import type { JITPaginatedMessageOptions } from './JITPaginatedMessageTypes';
+import type { AnyInteractableInteraction } from '../utility-types';
+
+export class JITPaginatedMessage extends PaginatedMessage {
+	public pageActions: (Map<string, PaginatedMessageAction> | null)[] = [];
+
+	public constructor({ pages, sharedActions, template, pageIndexPrefix, embedFooterSeparator }: JITPaginatedMessageOptions = {}) {
+		super({
+			actions: sharedActions, //
+			template,
+			pageIndexPrefix,
+			embedFooterSeparator
+		});
+
+		if (pages) {
+			this.setPages(pages.map(({ options }) => options));
+
+			for (let i = 0; i < pages.length; i++) {
+				const page = pages[i];
+				if (page.actions) {
+					this.addPageActions(page.actions, i);
+				}
+			}
+		}
+	}
+
+	public override hasCustomId(customId: string): boolean {
+		if (this.actions.has(customId)) return true;
+		return this.pageActions.some((actions) => actions && actions.has(customId));
+	}
+
+	/**
+	 * Clear all actions for a page and set the new ones.
+	 * @param actions The actions to set.
+	 * @param index The index of the page to set the actions to.
+	 */
+	public setPageActions(actions: PaginatedMessageAction[], index: number) {
+		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
+
+		this.pageActions[index]?.clear();
+		this.components[index] = [];
+		this.addPageActions(actions, index);
+		return this;
+	}
+
+	/**
+	 * Add the provided actions to a page.
+	 * @param actions The actions to add.
+	 * @param index The index of the page to add the actions to.
+	 */
+	public addPageActions(actions: PaginatedMessageAction[], index: number) {
+		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
+
+		for (const action of actions) this.addPageAction(action, index);
+		return this;
+	}
+
+	/**
+	 * Add the provided action to a page.
+	 * @param action The action to add.
+	 * @param index The index of the page to add the action to.
+	 */
+	public addPageAction(action: PaginatedMessageAction, index: number) {
+		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
+
+		if (!this.pageActions[index]) {
+			this.pageActions[index] = new Map<string, PaginatedMessageAction>();
+		}
+
+		if (actionIsButtonOrMenu(action)) {
+			this.pageActions[index]!.set(action.customId, action);
+		} else {
+			this.pageActions[index]!.set(action.url, action);
+		}
+
+		return this;
+	}
+
+	public override async resolveActions(
+		messageOrInteraction: Message | AnyInteractableInteraction,
+		targetUser: User,
+		index: number
+	): Promise<PaginatedMessageComponentUnion[]> {
+		const components = this.components[index];
+		if (!isNullish(components)) {
+			return components;
+		}
+
+		const actions = this.pageActions[index];
+
+		const sharedResolved = await this.handleActionLoad([...this.actions.values()], messageOrInteraction, targetUser);
+		const result: PaginatedMessageComponentUnion[] = createPartitionedMessageRow(sharedResolved);
+
+		if (!isNullish(actions)) {
+			const pageResolved = await this.handleActionLoad([...actions.values()], messageOrInteraction, targetUser);
+			const pageComponents = createPartitionedMessageRow(pageResolved);
+
+			result.push(...pageComponents);
+		}
+
+		this.components[index] = result;
+		return result;
+	}
+
+	protected override getAction(customId: string): PaginatedMessageAction {
+		let action = this.actions.get(customId);
+		if (isNullish(action)) {
+			action = this.pageActions[this.index]!.get(customId)!;
+		}
+
+		return action;
+	}
+}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/JITPaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/JITPaginatedMessageTypes.ts
@@ -1,0 +1,30 @@
+import type { EmbedBuilder, BaseMessageOptions } from 'discord.js';
+import type { PaginatedMessageAction, PaginatedMessagePage } from './PaginatedMessageTypes';
+
+export interface JITPaginatedMessagePage {
+	options: PaginatedMessagePage;
+	actions?: PaginatedMessageAction[];
+}
+
+export interface JITPaginatedMessageOptions {
+	/**
+	 * The pages to display in this {@link JITPaginatedMessage}
+	 */
+	pages?: JITPaginatedMessagePage[];
+	/**
+	 * Custom actions to provide when sending the paginated message
+	 */
+	sharedActions?: PaginatedMessageAction[];
+	/**
+	 * The {@link EmbedBuilder} or {@link MessageOptions} options to apply to the entire {@link JITPaginatedMessage}
+	 */
+	template?: EmbedBuilder | BaseMessageOptions;
+	/**
+	 * @seealso {@link PaginatedMessage.pageIndexPrefix}
+	 */
+	pageIndexPrefix?: string;
+	/**
+	 * @seealso {@link PaginatedMessage.embedFooterSeparator}
+	 */
+	embedFooterSeparator?: string;
+}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -1,7 +1,13 @@
 import type { Awaitable } from '@sapphire/utilities';
 import type {
+	APIActionRowComponent,
+	APIButtonComponent,
 	APIMessage,
+	APIStringSelectComponent,
+	ActionRowData,
 	BaseMessageOptions,
+	ButtonBuilder,
+	ButtonComponentData,
 	ButtonInteraction,
 	CommandInteraction,
 	EmbedBuilder,
@@ -11,6 +17,7 @@ import type {
 	InteractionCollector,
 	InteractionReplyOptions,
 	InteractionUpdateOptions,
+	JSONEncodable,
 	LinkButtonComponentData,
 	Message,
 	MessageComponentInteraction,
@@ -18,6 +25,7 @@ import type {
 	MessageReplyOptions,
 	SelectMenuComponentOptionData,
 	StageChannel,
+	StringSelectMenuBuilder,
 	StringSelectMenuComponentData,
 	StringSelectMenuInteraction,
 	User,
@@ -159,6 +167,11 @@ export type PaginatedMessageWrongUserInteractionReplyFunction = (
 export type PaginatedMessageEmbedResolvable = BaseMessageOptions['embeds'];
 
 export type PaginatedMessageMessageOptionsUnion = Omit<BaseMessageOptions, 'flags'> | WebhookMessageEditOptions;
+
+export type PaginatedMessageComponentUnion =
+	| JSONEncodable<APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>>
+	| ActionRowData<ButtonComponentData | StringSelectMenuComponentData | ButtonBuilder | StringSelectMenuBuilder>
+	| APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>;
 
 /**
  * @internal This is a duplicate of the same interface in `@sapphire/plugin-i18next`

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/index.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/index.ts
@@ -1,3 +1,5 @@
+export * from './JITPaginatedMessage';
+export * from './JITPaginatedMessageTypes';
 export * from './LazyPaginatedMessage';
 export * from './PaginatedFieldMessageEmbed';
 export * from './PaginatedMessage';

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -8,16 +8,14 @@ import {
 	type APIButtonComponent,
 	type APIStringSelectComponent,
 	type ActionRowComponentOptions,
-	type ActionRowData,
-	type ButtonComponentData,
-	type JSONEncodable,
-	type StringSelectMenuComponentData
+	type ButtonComponentData
 } from 'discord.js';
 import { isAnyInteractableInteraction, isMessageInstance } from '../type-guards';
 import type {
 	PaginatedMessageAction,
 	PaginatedMessageActionButton,
 	PaginatedMessageActionMenu,
+	PaginatedMessageComponentUnion,
 	SafeReplyToInteractionParameters
 } from './PaginatedMessageTypes';
 
@@ -40,13 +38,7 @@ export function isButtonComponentBuilder(component: ButtonBuilder | StringSelect
 	return component.data.type === ComponentType.Button;
 }
 
-export function createPartitionedMessageRow(
-	components: (ButtonBuilder | StringSelectMenuBuilder)[]
-): (
-	| JSONEncodable<APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>>
-	| ActionRowData<ButtonComponentData | StringSelectMenuComponentData | ButtonBuilder | StringSelectMenuBuilder>
-	| APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>
-)[] {
+export function createPartitionedMessageRow(components: (ButtonBuilder | StringSelectMenuBuilder)[]): PaginatedMessageComponentUnion[] {
 	// Partition the components into two groups: buttons and select menus
 	const [messageButtons, selectMenus] = partition(components, isButtonComponentBuilder);
 


### PR DESCRIPTION
`JITPaginatedMessage` adds support for per-page actions.

`PaginatedMessage` functionality has not changed for end-users. Internally, `actions` are now resolved to `components` on each page change and cached.

**TODO**:
- [ ] Test all `PaginatedMessage` methods with the new action loading
- [ ] Improve DX for adding/setting pages to `JITPaginatedMessage`
- [ ] See if `components` can be cached on first run instead of just page changes