### PR TITLE
feat(PaginatedMessage): add support for per-page actions

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -1,8 +1,9 @@
 import { isFunction } from '@sapphire/utilities';
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, Message, User } from 'discord.js';
 import { MessageBuilder } from '../builders/MessageBuilder';
 import { PaginatedMessage } from './PaginatedMessage';
 import type { PaginatedMessagePage } from './PaginatedMessageTypes';
+import type { AnyInteractableInteraction } from '../utility-types';
 
 /**
  * This is a LazyPaginatedMessage. Instead of resolving all pages that are functions on {@link PaginatedMessage.run} will resolve when requested.
@@ -11,18 +12,25 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 	/**
 	 * Only resolves the page corresponding with the handler's current index.
 	 */
-	public override async resolvePagesOnRun(): Promise<void> {
-		await this.resolvePage(this.index);
+	public override async resolvePagesOnRun(messageOrInteraction: Message | AnyInteractableInteraction, target: User): Promise<void> {
+		await this.resolvePage(messageOrInteraction, target, this.index);
 	}
 
 	/**
 	 * Resolves the page corresponding with the given index. This also resolves the index's before and after the given index.
+	 * @param messageOrInteraction The message or interaction that triggered this {@link LazyPaginatedMessage}.
+	 * @param target The user who will be able to interact with the buttons of this {@link LazyPaginatedMessage}.
 	 * @param index The index to resolve. Defaults to handler's current index.
+	 * @returns
 	 */
-	public override async resolvePage(index: number): Promise<PaginatedMessagePage> {
-		const promises = [super.resolvePage(index)];
-		if (this.hasPage(index - 1)) promises.push(super.resolvePage(index - 1));
-		if (this.hasPage(index + 1)) promises.push(super.resolvePage(index + 1));
+	public override async resolvePage(
+		messageOrInteraction: Message | AnyInteractableInteraction,
+		target: User,
+		index: number
+	): Promise<PaginatedMessagePage> {
+		const promises = [super.resolvePage(messageOrInteraction, target, index)];
+		if (this.hasPage(index - 1)) promises.push(super.resolvePage(messageOrInteraction, target, index - 1));
+		if (this.hasPage(index + 1)) promises.push(super.resolvePage(messageOrInteraction, target, index + 1));
 
 		const [result] = await Promise.all(promises);
 		return result;

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -21,7 +21,6 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 	 * @param messageOrInteraction The message or interaction that triggered this {@link LazyPaginatedMessage}.
 	 * @param target The user who will be able to interact with the buttons of this {@link LazyPaginatedMessage}.
 	 * @param index The index to resolve. Defaults to handler's current index.
-	 * @returns
 	 */
 	public override async resolvePage(
 		messageOrInteraction: Message | AnyInteractableInteraction,

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -1,9 +1,9 @@
 import { isFunction } from '@sapphire/utilities';
 import { EmbedBuilder, Message, User } from 'discord.js';
 import { MessageBuilder } from '../builders/MessageBuilder';
+import type { AnyInteractableInteraction } from '../utility-types';
 import { PaginatedMessage } from './PaginatedMessage';
 import type { PaginatedMessagePage } from './PaginatedMessageTypes';
-import type { AnyInteractableInteraction } from '../utility-types';
 
 /**
  * This is a LazyPaginatedMessage. Instead of resolving all pages that are functions on {@link PaginatedMessage.run} will resolve when requested.

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1272,20 +1272,16 @@ export class PaginatedMessage {
 				});
 
 				if (!this.stopPaginatedMessageCustomIds.includes(action.customId)) {
-					if (PaginatedMessage.defaultActions.some((entry) => actionIsButtonOrMenu(entry) && action.customId === entry.customId)) {
-						const newIndex = previousIndex === this.index ? previousIndex : this.index;
-						const messagePage = await this.resolvePage(this.response, targetUser, newIndex);
-						const updateOptions = isFunction(messagePage) ? await messagePage(newIndex, this.pages, this) : messagePage;
+					const newIndex = previousIndex === this.index ? previousIndex : this.index;
+					const messagePage = await this.resolvePage(this.response, targetUser, newIndex);
+					const updateOptions = isFunction(messagePage) ? await messagePage(newIndex, this.pages, this) : messagePage;
 
-						await safelyReplyToInteraction({
-							messageOrInteraction: interaction,
-							interactionEditReplyContent: updateOptions,
-							interactionReplyContent: { ...this.#thisMazeWasNotMeantForYouContent, ephemeral: true },
-							componentUpdateContent: updateOptions
-						});
-					} else if (!interaction.replied && !interaction.deferred) {
-						await interaction.deferUpdate();
-					}
+					await safelyReplyToInteraction({
+						messageOrInteraction: interaction,
+						interactionEditReplyContent: updateOptions,
+						interactionReplyContent: { ...this.#thisMazeWasNotMeantForYouContent, ephemeral: true },
+						componentUpdateContent: updateOptions
+					});
 				}
 			}
 		} else {

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1081,6 +1081,11 @@ export class PaginatedMessage {
 
 		// Load the page and return it:
 		const resolvedPage = await this.handlePageLoad(this.pages[index], index);
+		if (resolvedPage.actions) {
+			this.addPageActions(resolvedPage.actions, index);
+		}
+
+		const pageSpecificActions = this.pageActions.at(index);
 		const resolvedComponents: PaginatedMessageComponentUnion[] = [];
 
 		if (this.pages.length > 1) {
@@ -1090,10 +1095,8 @@ export class PaginatedMessage {
 			resolvedComponents.push(...sharedComponents);
 		}
 
-		if (!isNullish(resolvedPage.actions)) {
-			this.setPageActions(resolvedPage.actions, index);
-
-			const pageActions = await this.handleActionLoad([...resolvedPage.actions.values()], messageOrInteraction, target);
+		if (pageSpecificActions) {
+			const pageActions = await this.handleActionLoad([...pageSpecificActions.values()], messageOrInteraction, target);
 			const pageComponents = createPartitionedMessageRow(pageActions);
 
 			resolvedComponents.push(...pageComponents);

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -839,6 +839,17 @@ export class PaginatedMessage {
 	 * If you set this to true then you do not need to manually add `...PaginatedMessage.defaultActions` as seen in the first example.
 	 * The default value is `false` in order to match {@link PaginatedMessage.setActions}.
 	 *
+	 * @remark Internally we check if the provided index exists.
+	 * This means that calling this function _before_ calling any of the methods below this will not work as the amount of pages will always be 0,
+	 * thus the index will always be out of bounds. That said, make sure you first define your pages and _then_ define your actions for those pages.
+	 * - {@link PaginatedMessage.addAsyncPageEmbed}
+	 * - {@link PaginatedMessage.addPageBuilder}
+	 * - {@link PaginatedMessage.addPageContent}
+	 * - {@link PaginatedMessage.addPageEmbed}
+	 * - {@link PaginatedMessage.addPageEmbeds}
+	 * - {@link PaginatedMessage.addPages}
+	 * - {@link PaginatedMessage.setPages}
+	 *
 	 * @remark Add a select menu to the first page, while preserving all default actions:
 	 * @example
 	 * ```typescript
@@ -867,6 +878,17 @@ export class PaginatedMessage {
 	 * @param actions The actions to add.
 	 * @param index The index of the page to add the actions to.
 	 * @see {@link PaginatedMessage.setActions} for examples on how to structure the actions.
+	 *
+	 * @remark Internally we check if the provided index exists.
+	 * This means that calling this function _before_ calling any of the methods below this will not work as the amount of pages will always be 0,
+	 * thus the index will always be out of bounds. That said, make sure you first define your pages and _then_ define your actions for those pages.
+	 * - {@link PaginatedMessage.addAsyncPageEmbed}
+	 * - {@link PaginatedMessage.addPageBuilder}
+	 * - {@link PaginatedMessage.addPageContent}
+	 * - {@link PaginatedMessage.addPageEmbed}
+	 * - {@link PaginatedMessage.addPageEmbeds}
+	 * - {@link PaginatedMessage.addPages}
+	 * - {@link PaginatedMessage.setPages}
 	 */
 	public addPageActions(actions: PaginatedMessageAction[], index: number) {
 		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
@@ -883,6 +905,17 @@ export class PaginatedMessage {
 	 * @param action The action to add.
 	 * @param index The index of the page to add the action to.
 	 * @see {@link PaginatedMessage.setActions} for examples on how to structure the action.
+	 *
+	 * @remark Internally we check if the provided index exists.
+	 * This means that calling this function _before_ calling any of the methods below this will not work as the amount of pages will always be 0,
+	 * thus the index will always be out of bounds. That said, make sure you first define your pages and _then_ define your actions for those pages.
+	 * - {@link PaginatedMessage.addAsyncPageEmbed}
+	 * - {@link PaginatedMessage.addPageBuilder}
+	 * - {@link PaginatedMessage.addPageContent}
+	 * - {@link PaginatedMessage.addPageEmbed}
+	 * - {@link PaginatedMessage.addPageEmbeds}
+	 * - {@link PaginatedMessage.addPages}
+	 * - {@link PaginatedMessage.setPages}
 	 */
 	public addPageAction(action: PaginatedMessageAction, index: number) {
 		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -9,10 +9,10 @@ import {
 	IntentsBitField,
 	InteractionCollector,
 	InteractionType,
-	isJSONEncodable,
 	Partials,
 	StringSelectMenuBuilder,
 	StringSelectMenuInteraction,
+	isJSONEncodable,
 	userMention,
 	type APIEmbed,
 	type APIMessage,
@@ -834,13 +834,31 @@ export class PaginatedMessage {
 	/**
 	 * Clear all actions for a page and set the new ones.
 	 * @param actions The actions to set.
-	 * @param index The index of the page to set the actions to.
+	 * @param index The index of the page to set the actions to. **This is 0-based**.
+	 * @param includeDefaultActions Whether to merge in the {@link PaginatedMessage.defaultActions} when setting the actions for the page.
+	 * If you set this to true then you do not need to manually add `...PaginatedMessage.defaultActions` as seen in the first example.
+	 * The default value is `false` in order to match {@link PaginatedMessage.setActions}.
+	 *
+	 * @remark Add a select menu to the first page, while preserving all default actions:
+	 * @example
+	 * ```typescript
+	 * const display = new PaginatedMessage();
+	 *
+	 * display.setPageActions([
+	 *   {
+	 *     customId: 'custom_menu',
+	 *     type: ComponentType.StringSelect,
+	 *     run: (context) => console.log(context) // Do something here
+	 *   }
+	 * ], 0, true);
+	 * ```
+	 * @see {@link PaginatedMessage.setActions} for more examples on how to structure the action.
 	 */
-	public setPageActions(actions: PaginatedMessageAction[], index: number) {
+	public setPageActions(actions: PaginatedMessageAction[], index: number, includeDefaultActions = false) {
 		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
 
 		this.pageActions[index]?.clear();
-		this.addPageActions(actions, index);
+		this.addPageActions([...(includeDefaultActions ? PaginatedMessage.defaultActions : []), ...actions], index);
 		return this;
 	}
 
@@ -848,11 +866,15 @@ export class PaginatedMessage {
 	 * Add the provided actions to a page.
 	 * @param actions The actions to add.
 	 * @param index The index of the page to add the actions to.
+	 * @see {@link PaginatedMessage.setActions} for examples on how to structure the actions.
 	 */
 	public addPageActions(actions: PaginatedMessageAction[], index: number) {
 		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
 
-		for (const action of actions) this.addPageAction(action, index);
+		for (const action of actions) {
+			this.addPageAction(action, index);
+		}
+
 		return this;
 	}
 
@@ -860,6 +882,7 @@ export class PaginatedMessage {
 	 * Add the provided action to a page.
 	 * @param action The action to add.
 	 * @param index The index of the page to add the action to.
+	 * @see {@link PaginatedMessage.setActions} for examples on how to structure the action.
 	 */
 	public addPageAction(action: PaginatedMessageAction, index: number) {
 		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1284,7 +1284,7 @@ export class PaginatedMessage {
 							interactionReplyContent: { ...this.#thisMazeWasNotMeantForYouContent, ephemeral: true },
 							componentUpdateContent: updateOptions
 						});
-					} else if (!interaction.deferred) {
+					} else if (!interaction.replied && !interaction.deferred) {
 						await interaction.deferUpdate();
 					}
 				}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1116,6 +1116,7 @@ export class PaginatedMessage {
 	public clone(): PaginatedMessage {
 		const clone = new this.constructor({ pages: this.pages, actions: [] }).setIndex(this.index).setIdle(this.idle);
 		clone.actions = this.actions;
+		clone.pageActions = this.pageActions;
 		clone.response = this.response;
 		clone.template = this.template;
 		return clone;

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -494,16 +494,15 @@ export class PaginatedMessage {
 
 		const currentIndex = this.index;
 
-		this.pages[currentIndex] = page;
-		const messagePage = await this.handlePageLoad(page, currentIndex);
-		this.messages[currentIndex] = messagePage;
+		// Retrieve the current page
+		const oldPage = this.messages[currentIndex];
+		const oldOptions = isFunction(oldPage) ? await oldPage(currentIndex, this.pages, this) : oldPage;
 
-		await safelyReplyToInteraction({
-			messageOrInteraction: this.response,
-			interactionEditReplyContent: messagePage,
-			interactionReplyContent: { ...this.#thisMazeWasNotMeantForYouContent, ephemeral: true },
-			componentUpdateContent: messagePage
-		});
+		// Load the new page
+		const newPage = await this.handlePageLoad(page, currentIndex);
+
+		this.pages[currentIndex] = page;
+		this.messages[currentIndex] = { ...newPage, components: oldOptions?.components };
 
 		return this;
 	}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -835,9 +835,6 @@ export class PaginatedMessage {
 	 * Clear all actions for a page and set the new ones.
 	 * @param actions The actions to set.
 	 * @param index The index of the page to set the actions to. **This is 0-based**.
-	 * @param includeDefaultActions Whether to merge in the {@link PaginatedMessage.defaultActions} when setting the actions for the page.
-	 * If you set this to true then you do not need to manually add `...PaginatedMessage.defaultActions` as seen in the first example.
-	 * The default value is `false` in order to match {@link PaginatedMessage.setActions}.
 	 *
 	 * @remark Internally we check if the provided index exists.
 	 * This means that calling this function _before_ calling any of the methods below this will not work as the amount of pages will always be 0,
@@ -861,15 +858,15 @@ export class PaginatedMessage {
 	 *     type: ComponentType.StringSelect,
 	 *     run: (context) => console.log(context) // Do something here
 	 *   }
-	 * ], 0, true);
+	 * ], 0);
 	 * ```
 	 * @see {@link PaginatedMessage.setActions} for more examples on how to structure the action.
 	 */
-	public setPageActions(actions: PaginatedMessageAction[], index: number, includeDefaultActions = false) {
+	public setPageActions(actions: PaginatedMessageAction[], index: number) {
 		if (index < 0 || index > this.pages.length - 1) throw new Error('Provided index is out of bounds');
 
 		this.pageActions[index]?.clear();
-		this.addPageActions([...(includeDefaultActions ? PaginatedMessage.defaultActions : []), ...actions], index);
+		this.addPageActions(actions, index);
 		return this;
 	}
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -1,7 +1,13 @@
 import type { Awaitable } from '@sapphire/utilities';
 import type {
+	APIActionRowComponent,
+	APIButtonComponent,
 	APIMessage,
+	APIStringSelectComponent,
+	ActionRowData,
 	BaseMessageOptions,
+	ButtonBuilder,
+	ButtonComponentData,
 	ButtonInteraction,
 	CommandInteraction,
 	EmbedBuilder,
@@ -11,6 +17,7 @@ import type {
 	InteractionCollector,
 	InteractionReplyOptions,
 	InteractionUpdateOptions,
+	JSONEncodable,
 	LinkButtonComponentData,
 	Message,
 	MessageComponentInteraction,
@@ -18,6 +25,7 @@ import type {
 	MessageReplyOptions,
 	SelectMenuComponentOptionData,
 	StageChannel,
+	StringSelectMenuBuilder,
 	StringSelectMenuComponentData,
 	StringSelectMenuInteraction,
 	User,
@@ -158,7 +166,14 @@ export type PaginatedMessageWrongUserInteractionReplyFunction = (
 
 export type PaginatedMessageEmbedResolvable = BaseMessageOptions['embeds'];
 
-export type PaginatedMessageMessageOptionsUnion = Omit<BaseMessageOptions, 'flags'> | WebhookMessageEditOptions;
+export type PaginatedMessageMessageOptionsUnion = (Omit<BaseMessageOptions, 'flags'> | WebhookMessageEditOptions) & {
+	actions?: PaginatedMessageAction[];
+};
+
+export type PaginatedMessageComponentUnion =
+	| JSONEncodable<APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>>
+	| ActionRowData<ButtonComponentData | StringSelectMenuComponentData | ButtonBuilder | StringSelectMenuBuilder>
+	| APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>;
 
 /**
  * @internal This is a duplicate of the same interface in `@sapphire/plugin-i18next`

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -8,16 +8,14 @@ import {
 	type APIButtonComponent,
 	type APIStringSelectComponent,
 	type ActionRowComponentOptions,
-	type ActionRowData,
-	type ButtonComponentData,
-	type JSONEncodable,
-	type StringSelectMenuComponentData
+	type ButtonComponentData
 } from 'discord.js';
 import { isAnyInteractableInteraction, isMessageInstance } from '../type-guards';
 import type {
 	PaginatedMessageAction,
 	PaginatedMessageActionButton,
 	PaginatedMessageActionMenu,
+	PaginatedMessageComponentUnion,
 	SafeReplyToInteractionParameters
 } from './PaginatedMessageTypes';
 
@@ -40,13 +38,7 @@ export function isButtonComponentBuilder(component: ButtonBuilder | StringSelect
 	return component.data.type === ComponentType.Button;
 }
 
-export function createPartitionedMessageRow(
-	components: (ButtonBuilder | StringSelectMenuBuilder)[]
-): (
-	| JSONEncodable<APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>>
-	| ActionRowData<ButtonComponentData | StringSelectMenuComponentData | ButtonBuilder | StringSelectMenuBuilder>
-	| APIActionRowComponent<APIButtonComponent | APIStringSelectComponent>
-)[] {
+export function createPartitionedMessageRow(components: (ButtonBuilder | StringSelectMenuBuilder)[]): PaginatedMessageComponentUnion[] {
 	// Partition the components into two groups: buttons and select menus
 	const [messageButtons, selectMenus] = partition(components, isButtonComponentBuilder);
 


### PR DESCRIPTION
Per-page components for `PaginatedMessage` are now supported.

Page actions can be added by using the 3 methods `setPageActions`, `addPageActions`, and `addPageAction`.
