### PR TITLE
chore(deps): update `vitest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"turbo": "^1.9.3",
 		"typescript": "^5.0.4",
 		"vite": "^4.3.5",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/async-queue/package.json
+++ b/packages/async-queue/package.json
@@ -62,6 +62,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/bitfield/package.json
+++ b/packages/bitfield/package.json
@@ -63,6 +63,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -66,6 +66,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -37,7 +37,7 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/discord-utilities/package.json
+++ b/packages/discord-utilities/package.json
@@ -65,6 +65,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/duration/package.json
+++ b/packages/duration/package.json
@@ -63,6 +63,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -62,6 +62,6 @@
 		"@favware/cliff-jumper": "^2.0.0",
 		"@vitest/coverage-c8": "^0.31.0",
 		"tsup": "^6.7.0",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/eslint-plugin-result/package.json
+++ b/packages/eslint-plugin-result/package.json
@@ -53,7 +53,7 @@
 		"@favware/cliff-jumper": "^2.0.0",
 		"@vitest/coverage-c8": "^0.31.0",
 		"tsup": "^6.7.0",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	},
 	"dependencies": {
 		"@sapphire/result": "workspace:^",

--- a/packages/event-iterator/package.json
+++ b/packages/event-iterator/package.json
@@ -63,6 +63,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -65,6 +65,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/lexure/package.json
+++ b/packages/lexure/package.json
@@ -67,6 +67,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/lexure/tests/lib/ArgumentStream.test.ts
+++ b/packages/lexure/tests/lib/ArgumentStream.test.ts
@@ -243,7 +243,7 @@ describe('ArgumentStream', () => {
 
 			expect<ReturnType>(stream.find(cb)).toEqual(Option.some('aa'));
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.find(cb)).toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -256,12 +256,12 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.find(cb)).toEqual(Option.some('aa'));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledTimes(1);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.find(cb)).toEqual(Option.some('ac'));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(2);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.find(cb)).toEqual(Option.none);
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -296,7 +296,7 @@ describe('ArgumentStream', () => {
 
 			await expect<ReturnType>(stream.findAsync(cb)).resolves.toEqual(Option.some('aa'));
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findAsync(cb)).resolves.toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -309,12 +309,12 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.findAsync(cb)).resolves.toEqual(Option.some('aa'));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledTimes(1);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findAsync(cb)).resolves.toEqual(Option.some('ac'));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(2);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findAsync(cb)).resolves.toEqual(Option.none);
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -349,7 +349,7 @@ describe('ArgumentStream', () => {
 
 			expect<ReturnType>(stream.findMap(cb)).toEqual(Option.some('aaaa'));
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.findMap(cb)).toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -362,12 +362,12 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.findMap(cb)).toEqual(Option.some('aaaa'));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledTimes(1);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.findMap(cb)).toEqual(Option.some('acac'));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(2);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.findMap(cb)).toEqual(Option.none);
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -402,7 +402,7 @@ describe('ArgumentStream', () => {
 
 			await expect<ReturnType>(stream.findMapAsync(cb)).resolves.toEqual(Option.some('aaaa'));
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findMapAsync(cb)).resolves.toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -415,12 +415,12 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.findMapAsync(cb)).resolves.toEqual(Option.some('aaaa'));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledTimes(1);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findMapAsync(cb)).resolves.toEqual(Option.some('acac'));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(2);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findMapAsync(cb)).resolves.toEqual(Option.none);
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -459,7 +459,7 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.findParse(cb)).toEqual(Result.ok(4));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.findParse(cb)).toEqual(Result.err([]));
 			expect(cb).not.toHaveBeenCalled();
@@ -472,12 +472,12 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.findParse(cb)).toEqual(Result.ok(4));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledTimes(1);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.findParse(cb)).toEqual(Result.ok(2));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(2);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.findParse(cb)).toEqual(Result.err(['Could not parse a to a number', 'Could not parse b to a number']));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -523,7 +523,7 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.findParseAsync(cb)).resolves.toEqual(Result.ok(4));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findParseAsync(cb)).resolves.toEqual(Result.err([]));
 			expect(cb).not.toHaveBeenCalled();
@@ -536,12 +536,12 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.findParseAsync(cb)).resolves.toEqual(Result.ok(4));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledTimes(1);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findParseAsync(cb)).resolves.toEqual(Result.ok(2));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(2);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.findParseAsync(cb)).resolves.toEqual(
 				Result.err(['Could not parse a to a number', 'Could not parse b to a number'])
@@ -602,7 +602,7 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.filter(cb)).toEqual(Option.some(['aa']));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.filter(cb)).toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -615,7 +615,7 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.filter(cb)).toEqual(Option.some(['aa', 'ac']));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(4);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.filter(cb)).toEqual(Option.some([]));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -651,7 +651,7 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.filterAsync(cb)).resolves.toEqual(Option.some(['aa']));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.filterAsync(cb)).resolves.toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -664,7 +664,7 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.filterAsync(cb)).resolves.toEqual(Option.some(['aa', 'ac']));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(4);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.filterAsync(cb)).resolves.toEqual(Option.some([]));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -700,7 +700,7 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.filterMap(cb)).toEqual(Option.some(['aaaa']));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.filterMap(cb)).toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -713,7 +713,7 @@ describe('ArgumentStream', () => {
 			expect<ReturnType>(stream.filterMap(cb)).toEqual(Option.some(['aaaa', 'acac']));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(4);
-			cb.mockRestore();
+			cb.mockClear();
 
 			expect<ReturnType>(stream.filterMap(cb)).toEqual(Option.some([]));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
@@ -749,7 +749,7 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.filterMapAsync(cb)).resolves.toEqual(Option.some(['aaaa']));
 			expect([...stream.state.used]).toStrictEqual([0]);
 			expect(cb).toHaveBeenCalledOnce();
-			cb.mockReset();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.filterMapAsync(cb)).resolves.toEqual(Option.none);
 			expect(cb).not.toHaveBeenCalled();
@@ -762,7 +762,7 @@ describe('ArgumentStream', () => {
 			await expect<ReturnType>(stream.filterMapAsync(cb)).resolves.toEqual(Option.some(['aaaa', 'acac']));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);
 			expect(cb).toHaveBeenCalledTimes(4);
-			cb.mockRestore();
+			cb.mockClear();
 
 			await expect<ReturnType>(stream.filterMapAsync(cb)).resolves.toEqual(Option.some([]));
 			expect([...stream.state.used]).toStrictEqual([0, 2]);

--- a/packages/node-utilities/package.json
+++ b/packages/node-utilities/package.json
@@ -61,6 +61,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -56,6 +56,6 @@
 		"@favware/cliff-jumper": "^2.0.0",
 		"@vitest/coverage-c8": "^0.31.0",
 		"tsup": "^6.7.0",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/ratelimits/package.json
+++ b/packages/ratelimits/package.json
@@ -62,6 +62,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -66,7 +66,7 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	},
 	"dependencies": {
 		"tslib": "^2.5.0"

--- a/packages/snowflake/package.json
+++ b/packages/snowflake/package.json
@@ -62,6 +62,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/stopwatch/package.json
+++ b/packages/stopwatch/package.json
@@ -65,6 +65,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/timer-manager/package.json
+++ b/packages/timer-manager/package.json
@@ -63,6 +63,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -63,6 +63,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/ts-config/package.json
+++ b/packages/ts-config/package.json
@@ -71,6 +71,6 @@
 		"@sapphire/eslint-config": "workspace:^",
 		"@sapphire/eslint-plugin-result": "workspace:^",
 		"@vitest/coverage-c8": "^0.31.0",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -344,6 +344,6 @@
 		"typedoc": "^0.24.6",
 		"typedoc-json-parser": "^7.4.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.30.1"
+		"vitest": "^0.31.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,7 +795,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -809,7 +809,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -824,7 +824,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -844,7 +844,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -859,7 +859,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -902,7 +902,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -920,7 +920,7 @@ __metadata:
     prettier: ^2.8.8
     tsup: ^6.7.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -935,7 +935,7 @@ __metadata:
     tsup: ^6.7.0
     tsutils: ^3.21.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -950,7 +950,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -965,7 +965,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -997,7 +997,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1011,7 +1011,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1047,7 +1047,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.31.0
     prettier: ^2.8.8
     tsup: ^6.7.0
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1061,7 +1061,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1076,7 +1076,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1100,7 +1100,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1117,7 +1117,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1147,7 +1147,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1161,7 +1161,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1175,7 +1175,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.31.0
     tslib: ^2.5.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1190,7 +1190,7 @@ __metadata:
     typedoc: ^0.24.6
     typedoc-json-parser: ^7.4.0
     typescript: ^5.0.4
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -1478,57 +1478,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:0.30.1":
-  version: 0.30.1
-  resolution: "@vitest/expect@npm:0.30.1"
+"@vitest/expect@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@vitest/expect@npm:0.31.0"
   dependencies:
-    "@vitest/spy": 0.30.1
-    "@vitest/utils": 0.30.1
+    "@vitest/spy": 0.31.0
+    "@vitest/utils": 0.31.0
     chai: ^4.3.7
-  checksum: cd7728d1532fd9b9d9ca52f76be14af72f7cf28686e91f99b1537a30d46a4207021410163b1c460076d4ada7246f7f3bdc14989c44aff0814ef83e1cdf5e4ecf
+  checksum: a752592040e999a94881601dd1744f6b824169f0c22123da9fbbec6bcdb9d27220aa09a6bd0c63191cc239abf73dc2b86552603f9afed4e13b1690a1c2e7d642
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:0.30.1":
-  version: 0.30.1
-  resolution: "@vitest/runner@npm:0.30.1"
+"@vitest/runner@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@vitest/runner@npm:0.31.0"
   dependencies:
-    "@vitest/utils": 0.30.1
+    "@vitest/utils": 0.31.0
     concordance: ^5.0.4
     p-limit: ^4.0.0
     pathe: ^1.1.0
-  checksum: b8f9faa63f3e98671804ab403a1dc466a48548fa5ee5e276855f0bcc1fae528ca65476584fb5528dd62ba9865c54d147b1ae78fb0cafe337c043669dcb93e67d
+  checksum: 69d87de1ee03d24511e1381bbea222f1d7f4ed8bdc47f384ed3ec0a3243c2b79b3482069714042130dfc2c26107890330050f71371e07230d8fe710a45d50564
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:0.30.1":
-  version: 0.30.1
-  resolution: "@vitest/snapshot@npm:0.30.1"
+"@vitest/snapshot@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@vitest/snapshot@npm:0.31.0"
   dependencies:
     magic-string: ^0.30.0
     pathe: ^1.1.0
     pretty-format: ^27.5.1
-  checksum: 9e0b89ca6c2cb08f2061c3d6bf5f2a1a9481c0229b8772b8be1db515552f07ea184f4248ceb11ad976ee89e2402c14e48a5700bab6ea859167fe5d10920e939c
+  checksum: 0a8481c243bb8f649137f59e6aaa2d71681837ba94e34dc73139aa77e57ed96b99d45e083566d2185a5b91faaa8a8831e021cb4141d0f76ab9b867901d8f7a39
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:0.30.1":
-  version: 0.30.1
-  resolution: "@vitest/spy@npm:0.30.1"
+"@vitest/spy@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@vitest/spy@npm:0.31.0"
   dependencies:
     tinyspy: ^2.1.0
-  checksum: af2e0a3910dfaa6b5759acd4913ca3c21ac9ad543c0d1095c23bdbca1a7d4e5dab43d8bfc4b08025d24e84965d65ae83f2cdc6aad080eaf5faf06daf06af3271
+  checksum: 5edb20d66687823845a41af8408c41ff2667187615084b9743f66b74784e6374c2368ea6196ad47fdf62729c5f2292b507a1b979fe9efe0b1c70043e4ac91976
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:0.30.1":
-  version: 0.30.1
-  resolution: "@vitest/utils@npm:0.30.1"
+"@vitest/utils@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@vitest/utils@npm:0.31.0"
   dependencies:
     concordance: ^5.0.4
     loupe: ^2.3.6
     pretty-format: ^27.5.1
-  checksum: a685b6ba34b0173e4da388055dc2a22ba335a74cf99679f7036cea1d183e0ee804a01984148eaad0e0f48bfb786d33800ff6dd549b94f3d064e14caa0857ee62
+  checksum: 18197132d69f291ff6bf1ea29f8beace7748e3e8a071e03d08e3b083ebf4a5f4de599c3a062e109a7ceac68e83199b1bacef7b54f26a73e1fab33c06892b65c1
   languageName: node
   linkType: hard
 
@@ -5900,7 +5900,7 @@ __metadata:
     turbo: ^1.9.3
     typescript: ^5.0.4
     vite: ^4.3.5
-    vitest: ^0.30.1
+    vitest: ^0.31.0
   languageName: unknown
   linkType: soft
 
@@ -6124,13 +6124,6 @@ __metadata:
   dependencies:
     whatwg-url: ^7.0.0
   checksum: e94169be6461ab0ac0913313ad1719a14c60d402bd22b0ad96f4a6cffd79130d91ab5df0a5336a326b04d2df131c1409f563c9dc0d21a6ca6239a44b6c8dbd92
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "source-map@npm:0.6.1"
-  checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
   languageName: node
   linkType: hard
 
@@ -6465,10 +6458,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinypool@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "tinypool@npm:0.4.0"
-  checksum: 8abcac9e784793499f1eeeace8290c026454b9d7338c74029ce6a821643bab8dcab7caeb4051e39006baf681d6a62d57c3319e9c0f6e2317a45ab0fdbd76ee26
+"tinypool@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "tinypool@npm:0.5.0"
+  checksum: 4e0dfd8f28666d541c1d92304222edc4613f05d74fe2243c8520d466a2cc6596011a7072c1c41a7de7522351b82fda07e8038198e8f43673d8d69401c5903f8c
   languageName: node
   linkType: hard
 
@@ -7020,9 +7013,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:0.30.1":
-  version: 0.30.1
-  resolution: "vite-node@npm:0.30.1"
+"vite-node@npm:0.31.0":
+  version: 0.31.0
+  resolution: "vite-node@npm:0.31.0"
   dependencies:
     cac: ^6.7.14
     debug: ^4.3.4
@@ -7032,7 +7025,7 @@ __metadata:
     vite: ^3.0.0 || ^4.0.0
   bin:
     vite-node: vite-node.mjs
-  checksum: 2a17cca94aaf9ea689aeff0b5e900aab9e9385e97189446a7bc9c067f094556a5fcdff4a04367811694c3dcd2001bef7f5133ac66cdf4307d90742c30aff5fea
+  checksum: 8b4975382b1e97ac893a9b3daa6de43b0fd088c7c9b848f0ec36ab130c9f96cdb5b925f442c94fe1d166f3dfa77562feb281544771ec61544e8981960e3d8b06
   languageName: node
   linkType: hard
 
@@ -7073,18 +7066,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^0.30.1":
-  version: 0.30.1
-  resolution: "vitest@npm:0.30.1"
+"vitest@npm:^0.31.0":
+  version: 0.31.0
+  resolution: "vitest@npm:0.31.0"
   dependencies:
     "@types/chai": ^4.3.4
     "@types/chai-subset": ^1.3.3
     "@types/node": "*"
-    "@vitest/expect": 0.30.1
-    "@vitest/runner": 0.30.1
-    "@vitest/snapshot": 0.30.1
-    "@vitest/spy": 0.30.1
-    "@vitest/utils": 0.30.1
+    "@vitest/expect": 0.31.0
+    "@vitest/runner": 0.31.0
+    "@vitest/snapshot": 0.31.0
+    "@vitest/spy": 0.31.0
+    "@vitest/utils": 0.31.0
     acorn: ^8.8.2
     acorn-walk: ^8.2.0
     cac: ^6.7.14
@@ -7095,13 +7088,12 @@ __metadata:
     magic-string: ^0.30.0
     pathe: ^1.1.0
     picocolors: ^1.0.0
-    source-map: ^0.6.1
     std-env: ^3.3.2
     strip-literal: ^1.0.1
     tinybench: ^2.4.0
-    tinypool: ^0.4.0
+    tinypool: ^0.5.0
     vite: ^3.0.0 || ^4.0.0
-    vite-node: 0.30.1
+    vite-node: 0.31.0
     why-is-node-running: ^2.2.2
   peerDependencies:
     "@edge-runtime/vm": "*"
@@ -7131,7 +7123,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: 68e33226dde914600270df9834bdc1f45fd225250051c046c9bc53ca51b8e0bf76dee29a5cf1a51a4c1524f00c414f81764bb463734bdcc9c3f483f2140ec516
+  checksum: 9e612a8953f63accd5eeec95826ae0bbc31ac353cc7a2edb8ae8a603634f18640d6d2570f0e5ef37c80cf2e88fcb6dd8e8a916e43073af9672c2e9d110385094
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The methods were renamed around, the two methods we used were clearing the implementation, `mockClear` only resets the state.

https://github.com/vitest-dev/vitest/blob/77d071a91f81b6faef28cb30c6c5b617a661459d/packages/spy/src/index.ts#L224-L242
