### PR TITLE
refactor(bitfield): call entries only once

### DIFF
--- a/packages/bitfield/src/lib/BitField.ts
+++ b/packages/bitfield/src/lib/BitField.ts
@@ -1,4 +1,4 @@
-const FlagEntriesSymbol = Symbol('@sapphire/bitfield:bitfield.flags.entries');
+const FlagEntriesSymbol = Symbol('@sapphire/bitfield.flags.entries');
 
 export class BitField<Flags extends Record<string, number> | Record<string, bigint>> {
 	public readonly type: Flags[keyof Flags] extends number ? 'number' : 'bigint';

--- a/packages/bitfield/src/lib/BitField.ts
+++ b/packages/bitfield/src/lib/BitField.ts
@@ -1,11 +1,9 @@
-const FlagEntriesSymbol = Symbol('@sapphire/bitfield.flags.entries');
-
 export class BitField<Flags extends Record<string, number> | Record<string, bigint>> {
 	public readonly type: Flags[keyof Flags] extends number ? 'number' : 'bigint';
 	public readonly zero: Flags[keyof Flags] extends number ? 0 : 0n;
 	public readonly mask: ValueType<this>;
 	public readonly flags: Flags;
-	private readonly [FlagEntriesSymbol]: readonly [string, Flags[keyof Flags]][];
+	readonly #flatEntries: readonly [string, Flags[keyof Flags]][];
 
 	public constructor(flags: Readonly<Flags>) {
 		if (typeof flags !== 'object' || flags === null) {
@@ -24,7 +22,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 
 		this.type = type as any;
 		this.flags = flags;
-		this[FlagEntriesSymbol] = entries;
+		this.#flatEntries = entries;
 
 		if (type === 'number') {
 			this.zero = 0 as any;
@@ -230,7 +228,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	public toArray(field: ValueResolvable<this>): (keyof Flags)[] {
 		const bits = this.resolve(field);
 		const keys: (keyof Flags)[] = [];
-		for (const [key, bit] of this[FlagEntriesSymbol]) {
+		for (const [key, bit] of this.#flatEntries) {
 			// Inline `.has` code for lower overhead:
 			if ((bits & bit) === bit) keys.push(key);
 		}
@@ -263,7 +261,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	 */
 	public toObject(field: ValueResolvable<this>): Record<keyof Flags, boolean> {
 		const bits = this.resolve(field);
-		return Object.fromEntries(this[FlagEntriesSymbol].map(([key, bit]) => [key, (bits & bit) === bit])) as Record<keyof Flags, boolean>;
+		return Object.fromEntries(this.#flatEntries.map(([key, bit]) => [key, (bits & bit) === bit])) as Record<keyof Flags, boolean>;
 	}
 }
 

--- a/packages/bitfield/src/lib/BitField.ts
+++ b/packages/bitfield/src/lib/BitField.ts
@@ -1,9 +1,11 @@
+const FlagEntriesSymbol = Symbol('@sapphire/bitfield.flags.entries');
+
 export class BitField<Flags extends Record<string, number> | Record<string, bigint>> {
 	public readonly type: Flags[keyof Flags] extends number ? 'number' : 'bigint';
 	public readonly zero: Flags[keyof Flags] extends number ? 0 : 0n;
 	public readonly mask: ValueType<this>;
 	public readonly flags: Flags;
-	readonly #flatEntries: readonly [string, Flags[keyof Flags]][];
+	private readonly [FlagEntriesSymbol]: readonly [string, Flags[keyof Flags]][];
 
 	public constructor(flags: Readonly<Flags>) {
 		if (typeof flags !== 'object' || flags === null) {
@@ -22,7 +24,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 
 		this.type = type as any;
 		this.flags = flags;
-		this.#flatEntries = entries;
+		this[FlagEntriesSymbol] = entries;
 
 		if (type === 'number') {
 			this.zero = 0 as any;
@@ -228,7 +230,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	public toArray(field: ValueResolvable<this>): (keyof Flags)[] {
 		const bits = this.resolve(field);
 		const keys: (keyof Flags)[] = [];
-		for (const [key, bit] of this.#flatEntries) {
+		for (const [key, bit] of this[FlagEntriesSymbol]) {
 			// Inline `.has` code for lower overhead:
 			if ((bits & bit) === bit) keys.push(key);
 		}
@@ -261,7 +263,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	 */
 	public toObject(field: ValueResolvable<this>): Record<keyof Flags, boolean> {
 		const bits = this.resolve(field);
-		return Object.fromEntries(this.#flatEntries.map(([key, bit]) => [key, (bits & bit) === bit])) as Record<keyof Flags, boolean>;
+		return Object.fromEntries(this[FlagEntriesSymbol].map(([key, bit]) => [key, (bits & bit) === bit])) as Record<keyof Flags, boolean>;
 	}
 }
 

--- a/packages/bitfield/src/lib/BitField.ts
+++ b/packages/bitfield/src/lib/BitField.ts
@@ -1,8 +1,11 @@
+const FlagEntriesSymbol = Symbol('@sapphire/bitfield:bitfield.flags.entries');
+
 export class BitField<Flags extends Record<string, number> | Record<string, bigint>> {
 	public readonly type: Flags[keyof Flags] extends number ? 'number' : 'bigint';
 	public readonly zero: Flags[keyof Flags] extends number ? 0 : 0n;
 	public readonly mask: ValueType<this>;
 	public readonly flags: Flags;
+	private readonly [FlagEntriesSymbol]: readonly [string, Flags[keyof Flags]][];
 
 	public constructor(flags: Readonly<Flags>) {
 		if (typeof flags !== 'object' || flags === null) {
@@ -21,6 +24,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 
 		this.type = type as any;
 		this.flags = flags;
+		this[FlagEntriesSymbol] = entries;
 
 		if (type === 'number') {
 			this.zero = 0 as any;
@@ -226,7 +230,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	public toArray(field: ValueResolvable<this>): (keyof Flags)[] {
 		const bits = this.resolve(field);
 		const keys: (keyof Flags)[] = [];
-		for (const [key, bit] of Object.entries(this.flags)) {
+		for (const [key, bit] of this[FlagEntriesSymbol]) {
 			// Inline `.has` code for lower overhead:
 			if ((bits & bit) === bit) keys.push(key);
 		}
@@ -259,7 +263,7 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	 */
 	public toObject(field: ValueResolvable<this>): Record<keyof Flags, boolean> {
 		const bits = this.resolve(field);
-		return Object.fromEntries(Object.entries(this.flags).map(([key, bit]) => [key, (bits & bit) === bit])) as Record<keyof Flags, boolean>;
+		return Object.fromEntries(this[FlagEntriesSymbol].map(([key, bit]) => [key, (bits & bit) === bit])) as Record<keyof Flags, boolean>;
 	}
 }
 


### PR DESCRIPTION
This drastically improves performance of the `toArray` and `toObject` methods.

For the record about "but we don't use symbols for privates anywhere!", we still support Node.js v16, which has horrible `#private` performance, and tsup compiles the `#private` fields as weakmaps, nullifying the performance gains.