### PR TITLE
feat(snowflake): expose `processId` and `workerId`

### DIFF
--- a/packages/snowflake/src/lib/Snowflake.ts
+++ b/packages/snowflake/src/lib/Snowflake.ts
@@ -1,5 +1,7 @@
-const ProcessId = 1n;
-const WorkerId = 0n;
+const IncrementSymbol = Symbol('@sapphire/snowflake:snowflake.increment');
+const EpochSymbol = Symbol('@sapphire/snowflake:snowflake.epoch');
+const ProcessIdSymbol = Symbol('@sapphire/snowflake:snowflake.processId');
+const WorkerIdSymbol = Symbol('@sapphire/snowflake:snowflake.workerId');
 
 /**
  * A class for generating and deconstructing Twitter snowflakes.
@@ -22,29 +24,71 @@ export class Snowflake {
 	public decode = this.deconstruct;
 
 	/**
-	 * Internal incrementor for generating snowflakes
-	 * @internal
-	 */
-	#increment = 0n;
-
-	/**
 	 * Internal reference of the epoch passed in the constructor
 	 * @internal
 	 */
-	#epoch: bigint;
+	private readonly [EpochSymbol]: bigint;
+
+	/**
+	 * Internal incrementor for generating snowflakes
+	 * @internal
+	 */
+	private [IncrementSymbol] = 0n;
+
+	/**
+	 * The process ID that will be used by default in the generate method
+	 * @internal
+	 */
+	private [ProcessIdSymbol] = 1n;
+
+	/**
+	 * The worker ID that will be used by default in the generate method
+	 * @internal
+	 */
+	private [WorkerIdSymbol] = 0n;
 
 	/**
 	 * @param epoch the epoch to use
 	 */
 	public constructor(epoch: number | bigint | Date) {
-		this.#epoch = BigInt(epoch instanceof Date ? epoch.getTime() : epoch);
+		this[EpochSymbol] = BigInt(epoch instanceof Date ? epoch.getTime() : epoch);
 	}
 
 	/**
-	 * The epoch for this snowflake.
+	 * The epoch for this snowflake
 	 */
 	public get epoch(): bigint {
-		return this.#epoch;
+		return this[EpochSymbol];
+	}
+
+	/**
+	 * Gets the configured process ID
+	 */
+	public get processId(): bigint {
+		return this[ProcessIdSymbol];
+	}
+
+	/**
+	 * Sets the process ID that will be used by default for the {@link generate} method
+	 * @param value The new value, will be coerced to BigInt and masked with `0b11111n`
+	 */
+	public set processId(value: number | bigint) {
+		this[ProcessIdSymbol] = BigInt(value) & 0b11111n;
+	}
+
+	/**
+	 * Gets the configured worker ID
+	 */
+	public get workerId(): bigint {
+		return this[WorkerIdSymbol];
+	}
+
+	/**
+	 * Sets the worker ID that will be used by default for the {@link generate} method
+	 * @param value The new value, will be coerced to BigInt and masked with `0b11111n`
+	 */
+	public set workerId(value: number | bigint) {
+		this[WorkerIdSymbol] = BigInt(value) & 0b11111n;
 	}
 
 	/**
@@ -59,7 +103,12 @@ export class Snowflake {
 	 * ```
 	 * @returns A unique snowflake
 	 */
-	public generate({ increment, timestamp = Date.now(), workerId = WorkerId, processId = ProcessId }: SnowflakeGenerateOptions = {}) {
+	public generate({
+		increment,
+		timestamp = Date.now(),
+		workerId = this[WorkerIdSymbol],
+		processId = this[ProcessIdSymbol]
+	}: SnowflakeGenerateOptions = {}) {
 		if (timestamp instanceof Date) timestamp = BigInt(timestamp.getTime());
 		else if (typeof timestamp === 'number') timestamp = BigInt(timestamp);
 		else if (typeof timestamp !== 'bigint') {
@@ -68,12 +117,12 @@ export class Snowflake {
 
 		if (typeof increment === 'bigint' && increment >= 4095n) increment = 0n;
 		else {
-			increment = this.#increment++;
-			if (this.#increment >= 4095n) this.#increment = 0n;
+			increment = this[IncrementSymbol]++;
+			if (this[IncrementSymbol] >= 4095n) this[IncrementSymbol] = 0n;
 		}
 
 		// timestamp, workerId, processId, increment
-		return ((timestamp - this.#epoch) << 22n) | ((workerId & 0b11111n) << 17n) | ((processId & 0b11111n) << 12n) | increment;
+		return ((timestamp - this[EpochSymbol]) << 22n) | ((workerId & 0b11111n) << 17n) | ((processId & 0b11111n) << 12n) | increment;
 	}
 
 	/**
@@ -88,13 +137,14 @@ export class Snowflake {
 	 */
 	public deconstruct(id: string | bigint): DeconstructedSnowflake {
 		const bigIntId = BigInt(id);
+		const epoch = this[EpochSymbol];
 		return {
 			id: bigIntId,
-			timestamp: (bigIntId >> 22n) + this.#epoch,
+			timestamp: (bigIntId >> 22n) + epoch,
 			workerId: (bigIntId >> 17n) & 0b11111n,
 			processId: (bigIntId >> 12n) & 0b11111n,
 			increment: bigIntId & 0b111111111111n,
-			epoch: this.#epoch
+			epoch
 		};
 	}
 
@@ -104,7 +154,7 @@ export class Snowflake {
 	 * @returns The UNIX timestamp that is stored in `id`.
 	 */
 	public timestampFrom(id: string | bigint): number {
-		return Number((BigInt(id) >> 22n) + this.#epoch);
+		return Number((BigInt(id) >> 22n) + this[EpochSymbol]);
 	}
 
 	/**

--- a/packages/snowflake/src/lib/Snowflake.ts
+++ b/packages/snowflake/src/lib/Snowflake.ts
@@ -1,3 +1,8 @@
+const IncrementSymbol = Symbol('@sapphire/snowflake.increment');
+const EpochSymbol = Symbol('@sapphire/snowflake.epoch');
+const ProcessIdSymbol = Symbol('@sapphire/snowflake.processId');
+const WorkerIdSymbol = Symbol('@sapphire/snowflake.workerId');
+
 /**
  * A class for generating and deconstructing Twitter snowflakes.
  *
@@ -22,45 +27,45 @@ export class Snowflake {
 	 * Internal reference of the epoch passed in the constructor
 	 * @internal
 	 */
-	readonly #epoch: bigint;
+	private readonly [EpochSymbol]: bigint;
 
 	/**
 	 * Internal incrementor for generating snowflakes
 	 * @internal
 	 */
-	#increment = 0n;
+	private [IncrementSymbol] = 0n;
 
 	/**
 	 * The process ID that will be used by default in the generate method
 	 * @internal
 	 */
-	#processId = 1n;
+	private [ProcessIdSymbol] = 1n;
 
 	/**
 	 * The worker ID that will be used by default in the generate method
 	 * @internal
 	 */
-	#workerId = 0n;
+	private [WorkerIdSymbol] = 0n;
 
 	/**
 	 * @param epoch the epoch to use
 	 */
 	public constructor(epoch: number | bigint | Date) {
-		this.#epoch = BigInt(epoch instanceof Date ? epoch.getTime() : epoch);
+		this[EpochSymbol] = BigInt(epoch instanceof Date ? epoch.getTime() : epoch);
 	}
 
 	/**
 	 * The epoch for this snowflake
 	 */
 	public get epoch(): bigint {
-		return this.#epoch;
+		return this[EpochSymbol];
 	}
 
 	/**
 	 * Gets the configured process ID
 	 */
 	public get processId(): bigint {
-		return this.#processId;
+		return this[ProcessIdSymbol];
 	}
 
 	/**
@@ -68,14 +73,14 @@ export class Snowflake {
 	 * @param value The new value, will be coerced to BigInt and masked with `0b11111n`
 	 */
 	public set processId(value: number | bigint) {
-		this.#processId = BigInt(value) & 0b11111n;
+		this[ProcessIdSymbol] = BigInt(value) & 0b11111n;
 	}
 
 	/**
 	 * Gets the configured worker ID
 	 */
 	public get workerId(): bigint {
-		return this.#workerId;
+		return this[WorkerIdSymbol];
 	}
 
 	/**
@@ -83,7 +88,7 @@ export class Snowflake {
 	 * @param value The new value, will be coerced to BigInt and masked with `0b11111n`
 	 */
 	public set workerId(value: number | bigint) {
-		this.#workerId = BigInt(value) & 0b11111n;
+		this[WorkerIdSymbol] = BigInt(value) & 0b11111n;
 	}
 
 	/**
@@ -98,7 +103,12 @@ export class Snowflake {
 	 * ```
 	 * @returns A unique snowflake
 	 */
-	public generate({ increment, timestamp = Date.now(), workerId = this.#workerId, processId = this.#processId }: SnowflakeGenerateOptions = {}) {
+	public generate({
+		increment,
+		timestamp = Date.now(),
+		workerId = this[WorkerIdSymbol],
+		processId = this[ProcessIdSymbol]
+	}: SnowflakeGenerateOptions = {}) {
 		if (timestamp instanceof Date) timestamp = BigInt(timestamp.getTime());
 		else if (typeof timestamp === 'number') timestamp = BigInt(timestamp);
 		else if (typeof timestamp !== 'bigint') {
@@ -107,12 +117,12 @@ export class Snowflake {
 
 		if (typeof increment === 'bigint' && increment >= 4095n) increment = 0n;
 		else {
-			increment = this.#increment++;
-			if (increment >= 4095n) this.#increment = 0n;
+			increment = this[IncrementSymbol]++;
+			if (this[IncrementSymbol] >= 4095n) this[IncrementSymbol] = 0n;
 		}
 
 		// timestamp, workerId, processId, increment
-		return ((timestamp - this.#epoch) << 22n) | ((workerId & 0b11111n) << 17n) | ((processId & 0b11111n) << 12n) | increment;
+		return ((timestamp - this[EpochSymbol]) << 22n) | ((workerId & 0b11111n) << 17n) | ((processId & 0b11111n) << 12n) | increment;
 	}
 
 	/**
@@ -127,7 +137,7 @@ export class Snowflake {
 	 */
 	public deconstruct(id: string | bigint): DeconstructedSnowflake {
 		const bigIntId = BigInt(id);
-		const epoch = this.#epoch;
+		const epoch = this[EpochSymbol];
 		return {
 			id: bigIntId,
 			timestamp: (bigIntId >> 22n) + epoch,
@@ -144,7 +154,7 @@ export class Snowflake {
 	 * @returns The UNIX timestamp that is stored in `id`.
 	 */
 	public timestampFrom(id: string | bigint): number {
-		return Number((BigInt(id) >> 22n) + this.#epoch);
+		return Number((BigInt(id) >> 22n) + this[EpochSymbol]);
 	}
 
 	/**

--- a/packages/snowflake/src/lib/Snowflake.ts
+++ b/packages/snowflake/src/lib/Snowflake.ts
@@ -1,7 +1,7 @@
-const IncrementSymbol = Symbol('@sapphire/snowflake:snowflake.increment');
-const EpochSymbol = Symbol('@sapphire/snowflake:snowflake.epoch');
-const ProcessIdSymbol = Symbol('@sapphire/snowflake:snowflake.processId');
-const WorkerIdSymbol = Symbol('@sapphire/snowflake:snowflake.workerId');
+const IncrementSymbol = Symbol('@sapphire/snowflake.increment');
+const EpochSymbol = Symbol('@sapphire/snowflake.epoch');
+const ProcessIdSymbol = Symbol('@sapphire/snowflake.processId');
+const WorkerIdSymbol = Symbol('@sapphire/snowflake.workerId');
 
 /**
  * A class for generating and deconstructing Twitter snowflakes.


### PR DESCRIPTION
This PR also switches `#private` properties to symbol properties for higher performance. Also added missing tests to near 100% coverage.