### PR TITLE
refactor(snowflake): handle out-of-bounds `increment` correctly

### DIFF
--- a/packages/snowflake/src/lib/Snowflake.ts
+++ b/packages/snowflake/src/lib/Snowflake.ts
@@ -131,7 +131,6 @@ export class Snowflake {
 		}
 
 		if (typeof increment !== 'bigint') {
-			// The increment was within
 			increment = this[IncrementSymbol];
 			this[IncrementSymbol] = (increment + 1n) & MaximumIncrement;
 		}

--- a/packages/snowflake/tests/lib/Snowflake.test.ts
+++ b/packages/snowflake/tests/lib/Snowflake.test.ts
@@ -77,24 +77,6 @@ describe('Snowflake', () => {
 			expect(snow.toString()).toBe(testId);
 		});
 
-		test('GIVEN timestamp as Date and increment lower than 0n THEN returns predefined snowflake', () => {
-			const testId = '3971046231244808191';
-			const testDate = new Date(2524608000000);
-			const snowflake = new Snowflake(sampleEpoch);
-			const snow = snowflake.generate({ timestamp: testDate, increment: -1n });
-
-			expect(snow.toString()).toBe(testId);
-		});
-
-		test('GIVEN timestamp as Date and increment higher than 4095n THEN returns predefined snowflake', () => {
-			const testId = '3971046231244805000';
-			const testDate = new Date(2524608000000);
-			const snowflake = new Snowflake(sampleEpoch);
-			const snow = snowflake.generate({ timestamp: testDate, increment: 5000n });
-
-			expect(snow.toString()).toBe(testId);
-		});
-
 		test('GIVEN empty object options THEN returns predefined snowflake', () => {
 			const testId = '4096';
 			const snowflake = new Snowflake(sampleEpoch);
@@ -153,6 +135,30 @@ describe('Snowflake', () => {
 
 			// Validate that there are no duplicate IDs
 			expect(setOf10Snowflakes.size).toBe(arrayOf10Snowflakes.length);
+		});
+
+		test('GIVEN timestamp as Date and increment lower than 0n THEN returns predefined snowflake', () => {
+			const testId = '8191';
+			const snowflake = new Snowflake(sampleEpoch);
+			const snow = snowflake.generate({ increment: -1n });
+
+			expect(snow.toString()).toBe(testId);
+		});
+
+		test('GIVEN timestamp as Date and increment higher than 4095n THEN returns predefined snowflake', () => {
+			const testId = '6196';
+			const snowflake = new Snowflake(sampleEpoch);
+			const snow = snowflake.generate({ increment: 2100n });
+
+			expect(snow.toString()).toBe(testId);
+		});
+
+		test('GIVEN timestamp as Date and increment higher than 4095n THEN returns predefined snowflake', () => {
+			const testId = '5000';
+			const snowflake = new Snowflake(sampleEpoch);
+			const snow = snowflake.generate({ increment: 5000n });
+
+			expect(snow.toString()).toBe(testId);
 		});
 
 		test('GIVEN overflowing processId THEN generates ID with truncated processId', () => {


### PR DESCRIPTION
This fixes several issues at once, and also increases performance.

- The code was cycling at 4095, making the effective range [0, 4094] instead of [0, 4095].
- When passing a custom increment over the limit (>4095), it would be set to 0, which can cause duplication issues.
- When passing a custom increment that was <=4095, it would call the `else` branch which would then override with the defaults.
- Were custom increments to be allowed, negative values would overflow the rest of the data. For example, fixing the branching code:
  ```js
  DiscordSnowflake.generate({ increment: -1n, timestamp: 1600000000000n, processId: 1n, workerId: 0n });
  ```
  Would return... `-1`, which is can be deconstructed as:
  ```js
  {
    id: -1n,
    timestamp: 1420070399999n,
    workerId: 31n,
    processId: 31n,
    increment: 4095n,
    epoch: 1420070400000n
  }
  ```
  Which is nowhere close to the input data.

Also, the new code should be a bit faster now that it accesses the private field exactly only twice, rather than 2 or 3 times (when cycling) and uses less conditional branches.

This PR also adds exports for the maximum values each field can have: `MaximumWorkerId`, `MaximumProcessId`, and `MaximumIncrement`.