### PR TITLE
feat(bitfield): add iterator methods

### DIFF
--- a/packages/bitfield/src/lib/BitField.ts
+++ b/packages/bitfield/src/lib/BitField.ts
@@ -228,14 +228,82 @@ export class BitField<Flags extends Record<string, number> | Record<string, bigi
 	 * ```
 	 */
 	public toArray(field: ValueResolvable<this>): (keyof Flags)[] {
+		return [...this.toKeys(field)];
+	}
+
+	/**
+	 * Retrieves an iterator of the properties from {@link Flags} whose values are contained in `field`.
+	 * @param field The field to convert to an iterator.
+	 * @returns An iterator with the keys of the {@link BitField}'s flag properties whose value are contained in `field`.
+	 * @example
+	 * ```typescript
+	 * const bitfield = new BitField({
+	 * 	Read:   0b0001,
+	 * 	Write:  0b0010,
+	 * 	Edit:   0b0100,
+	 * 	Delete: 0b1000
+	 * });
+	 *
+	 * [...bitfield.toKeys(0b0101)];
+	 * // ['Read', 'Edit']
+	 * ```
+	 */
+	public *toKeys(field: ValueResolvable<this>): IterableIterator<keyof Flags> {
 		const bits = this.resolve(field);
-		const keys: (keyof Flags)[] = [];
 		for (const [key, bit] of this[FlagEntriesSymbol]) {
 			// Inline `.has` code for lower overhead:
-			if ((bits & bit) === bit) keys.push(key);
+			if ((bits & bit) === bit) yield key;
 		}
+	}
 
-		return keys;
+	/**
+	 * Retrieves an iterator of the values from {@link Flags} whose values are contained in `field`.
+	 * @param field The field to convert to an iterator.
+	 * @returns An iterator with the values of the {@link BitField}'s flag properties whose value are contained in `field`.
+	 * @example
+	 * ```typescript
+	 * const bitfield = new BitField({
+	 * 	Read:   0b0001,
+	 * 	Write:  0b0010,
+	 * 	Edit:   0b0100,
+	 * 	Delete: 0b1000
+	 * });
+	 *
+	 * [...bitfield.toValues(0b0101)];
+	 * // [0b0001, 0b0100]
+	 * ```
+	 */
+	public *toValues(field: ValueResolvable<this>): IterableIterator<ValueType<this>> {
+		const bits = this.resolve(field);
+		for (const [_, bit] of this[FlagEntriesSymbol]) {
+			// Inline `.has` code for lower overhead:
+			if ((bits & bit) === bit) yield bit as unknown as ValueType<this>;
+		}
+	}
+
+	/**
+	 * Retrieves an iterator of the entries from {@link Flags} whose values are contained in `field`.
+	 * @param field The field to convert to an iterator.
+	 * @returns An iterator with the entries of the {@link BitField}'s flag properties whose value are contained in `field`.
+	 * @example
+	 * ```typescript
+	 * const bitfield = new BitField({
+	 * 	Read:   0b0001,
+	 * 	Write:  0b0010,
+	 * 	Edit:   0b0100,
+	 * 	Delete: 0b1000
+	 * });
+	 *
+	 * [...bitfield.toEntries(0b0101)];
+	 * // [['Read', 0b0001], ['Edit', 0b0100]]
+	 * ```
+	 */
+	public *toEntries(field: ValueResolvable<this>): IterableIterator<[key: keyof Flags, value: ValueType<this>]> {
+		const bits = this.resolve(field);
+		for (const [key, bit] of this[FlagEntriesSymbol]) {
+			// Inline `.has` code for lower overhead:
+			if ((bits & bit) === bit) yield [key, bit as unknown as ValueType<this>];
+		}
 	}
 
 	/**

--- a/packages/bitfield/tests/lib/BitField.test.ts
+++ b/packages/bitfield/tests/lib/BitField.test.ts
@@ -327,6 +327,105 @@ describe('BitField', () => {
 			});
 		});
 
+		describe('toKeys', () => {
+			test('GIVEN ∅ THEN returns empty iterator', () => {
+				const given = [...bitfield.toKeys(bitfield.zero)];
+				const expected = [] as const;
+
+				expect<string[]>(given).toEqual(expected);
+			});
+
+			test('GIVEN multiple values THEN returns iterator with given values', () => {
+				const given = [...bitfield.toKeys(['Read', 'Delete'])];
+				const expected = ['Read', 'Delete'] as const;
+
+				expect<string[]>(given).toEqual(expected);
+			});
+
+			test('GIVEN duplicated values THEN returns iterator with deduplicated values', () => {
+				const given = [...bitfield.toKeys(['Read', 'Delete', 'Read'])];
+				const expected = ['Read', 'Delete'] as const;
+
+				expect<string[]>(given).toEqual(expected);
+			});
+
+			test('GIVEN out-of-range values THEN returns iterator with correct values', () => {
+				const given = [...bitfield.toKeys(['Read', 'Delete', 16])];
+				const expected = ['Read', 'Delete'] as const;
+
+				expect<string[]>(given).toEqual(expected);
+			});
+		});
+
+		describe('toValues', () => {
+			test('GIVEN ∅ THEN returns empty iterator', () => {
+				const given = [...bitfield.toValues(bitfield.zero)];
+				const expected = [] as const;
+
+				expect<number[]>(given).toEqual(expected);
+			});
+
+			test('GIVEN multiple values THEN returns iterator with given values', () => {
+				const given = [...bitfield.toValues(['Read', 'Delete'])];
+				const expected = [1, 8] as const;
+
+				expect<number[]>(given).toEqual(expected);
+			});
+
+			test('GIVEN duplicated values THEN returns iterator with deduplicated values', () => {
+				const given = [...bitfield.toValues(['Read', 'Delete', 'Read'])];
+				const expected = [1, 8] as const;
+
+				expect<number[]>(given).toEqual(expected);
+			});
+
+			test('GIVEN out-of-range values THEN returns iterator with correct values', () => {
+				const given = [...bitfield.toValues(['Read', 'Delete', 16])];
+				const expected = [1, 8] as const;
+
+				expect<number[]>(given).toEqual(expected);
+			});
+		});
+
+		describe('toEntries', () => {
+			test('GIVEN ∅ THEN returns empty iterator', () => {
+				const given = [...bitfield.toEntries(bitfield.zero)];
+				const expected = [] as const;
+
+				expect<[string, number][]>(given).toEqual(expected);
+			});
+
+			test('GIVEN multiple values THEN returns iterator with given values', () => {
+				const given = [...bitfield.toEntries(['Read', 'Delete'])];
+				const expected = [
+					['Read', 1],
+					['Delete', 8]
+				] as const;
+
+				expect<[string, number][]>(given).toEqual(expected);
+			});
+
+			test('GIVEN duplicated values THEN returns iterator with deduplicated values', () => {
+				const given = [...bitfield.toEntries(['Read', 'Delete', 'Read'])];
+				const expected = [
+					['Read', 1],
+					['Delete', 8]
+				] as const;
+
+				expect<[string, number][]>(given).toEqual(expected);
+			});
+
+			test('GIVEN out-of-range values THEN returns iterator with correct values', () => {
+				const given = [...bitfield.toEntries(['Read', 'Delete', 16])];
+				const expected = [
+					['Read', 1],
+					['Delete', 8]
+				] as const;
+
+				expect<[string, number][]>(given).toEqual(expected);
+			});
+		});
+
 		describe('toObject', () => {
 			type Expected = { [K in keyof typeof NumberFlags]: boolean };
 


### PR DESCRIPTION
The discord.js counterpart supports has [`[Symbol.iterator]`](https://github.com/discordjs/discord.js/blob/46167a79d7d0cac5599459a31c33b2bbcf6e06da/packages/discord.js/src/util/BitField.js#L143-L147) but we didn't support any kind of iteration, so I added the iterator methods to conform to an iterable's methods (`.keys()`, `.values()`, and `.entries()`).
