### PR TITLE
refactor(PaginatedMessage): update types and make `run` on actions optional

### DIFF
--- a/packages/discord.js-utilities/README.md
+++ b/packages/discord.js-utilities/README.md
@@ -19,7 +19,7 @@ There many functions that are always extremely useful to have when developing bo
 
 ## Features
 
--   Written in TypeScript
+-   Written in TypeScript.
 -   Bundled with esbuild to provide size-optimal bundles
 -   Offers CommonJS and ESM bundles
 

--- a/packages/discord.js-utilities/README.md
+++ b/packages/discord.js-utilities/README.md
@@ -62,4 +62,4 @@ Thank you to all the people who already contributed to Sapphire!
 
 [contributing]: https://github.com/sapphiredev/.github/blob/main/.github/CONTRIBUTING.md
 [@sapphire/discord-utilities]: https://www.npmjs.com/package/@sapphire/discord-utilities
-[discord.js]: https://discord.js.org
+[discord.js]: https://discordjs.dev

--- a/packages/discord.js-utilities/README.md
+++ b/packages/discord.js-utilities/README.md
@@ -20,7 +20,7 @@ There many functions that are always extremely useful to have when developing bo
 ## Features
 
 -   Written in TypeScript.
--   Bundled with esbuild to provide size-optimal bundles
+-   Bundled with esbuild to provide size-optimal bundles.
 -   Offers CommonJS and ESM bundles
 
 ## Installation

--- a/packages/discord.js-utilities/README.md
+++ b/packages/discord.js-utilities/README.md
@@ -21,7 +21,7 @@ There many functions that are always extremely useful to have when developing bo
 
 -   Written in TypeScript.
 -   Bundled with esbuild to provide size-optimal bundles.
--   Offers CommonJS and ESM bundles
+-   Offers CommonJS and ESM bundles.
 
 ## Installation
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -3,7 +3,7 @@ import { EmbedBuilder, Message, User } from 'discord.js';
 import { MessageBuilder } from '../builders/MessageBuilder';
 import type { AnyInteractableInteraction } from '../utility-types';
 import { PaginatedMessage } from './PaginatedMessage';
-import type { PaginatedMessagePage } from './PaginatedMessageTypes';
+import type { PaginatedMessageResolvedPage } from './PaginatedMessageTypes';
 
 /**
  * This is a LazyPaginatedMessage. Instead of resolving all pages that are functions on {@link PaginatedMessage.run} will resolve when requested.
@@ -26,7 +26,7 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 		messageOrInteraction: Message | AnyInteractableInteraction,
 		target: User,
 		index: number
-	): Promise<PaginatedMessagePage> {
+	): Promise<PaginatedMessageResolvedPage> {
 		const promises = [super.resolvePage(messageOrInteraction, target, index)];
 		if (this.hasPage(index - 1)) promises.push(super.resolvePage(messageOrInteraction, target, index - 1));
 		if (this.hasPage(index + 1)) promises.push(super.resolvePage(messageOrInteraction, target, index + 1));

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -48,7 +48,7 @@ export type PaginatedMessageAction =
 	| PaginatedMessageActionChannelMenu;
 
 export interface PaginatedMessageActionRun {
-	run(context: PaginatedMessageActionContext): Awaitable<unknown>;
+	run?(context: PaginatedMessageActionContext): Awaitable<unknown>;
 }
 
 /**
@@ -92,10 +92,7 @@ export type PaginatedMessageActionLink = LinkButtonComponentData;
  * }
  * ```
  */
-export type PaginatedMessageActionStringMenu = PaginatedMessageActionRun &
-	// TODO: When DiscordJS fixes the `options` being marked as undefined we can merge this Omit and Pick back into a regular intersection. (ref: https://github.com/discordjs/discord.js/pull/9515)
-	Omit<StringSelectMenuComponentData, 'options'> &
-	Required<Pick<StringSelectMenuComponentData, 'options'>>;
+export type PaginatedMessageActionStringMenu = PaginatedMessageActionRun & StringSelectMenuComponentData;
 
 /**
  * To utilize User Select Menus you can pass an object with the structure of {@link PaginatedMessageActionUserMenu} to {@link PaginatedMessage} actions.
@@ -241,6 +238,8 @@ export type PaginatedMessagePage =
 	| ((index: number, pages: PaginatedMessagePage[], handler: PaginatedMessage) => Awaitable<PaginatedMessageMessageOptionsUnion>)
 	| PaginatedMessageMessageOptionsUnion;
 
+export type PaginatedMessageResolvedPage = Omit<BaseMessageOptions, 'flags'> | WebhookMessageEditOptions;
+
 /**
  * The type of the custom function that can be set for the {@link PaginatedMessage.selectMenuOptions}
  */
@@ -260,7 +259,7 @@ export type PaginatedMessageWrongUserInteractionReplyFunction = (
 
 export type PaginatedMessageEmbedResolvable = BaseMessageOptions['embeds'];
 
-export type PaginatedMessageMessageOptionsUnion = (Omit<BaseMessageOptions, 'flags'> | WebhookMessageEditOptions) & {
+export type PaginatedMessageMessageOptionsUnion = Omit<PaginatedMessageResolvedPage, 'components'> & {
 	actions?: PaginatedMessageAction[];
 };
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -2,6 +2,7 @@ import { chunk, partition } from '@sapphire/utilities';
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
+	ButtonStyle,
 	ComponentType,
 	type APIActionRowComponent,
 	type APIMessageActionRowComponent,
@@ -17,7 +18,13 @@ import {
 import { isAnyInteractableInteraction, isMessageInstance } from '../type-guards';
 import type {
 	PaginatedMessageAction,
+	PaginatedMessageActionButton,
+	PaginatedMessageActionChannelMenu,
 	PaginatedMessageActionLink,
+	PaginatedMessageActionMentionableMenu,
+	PaginatedMessageActionRoleMenu,
+	PaginatedMessageActionStringMenu,
+	PaginatedMessageActionUserMenu,
 	PaginatedMessageComponentUnion,
 	SafeReplyToInteractionParameters
 } from './PaginatedMessageTypes';
@@ -59,6 +66,34 @@ export function isMessageChannelSelectInteractionData(interaction: ActionRowComp
 
 export function isButtonComponentBuilder(component: MessageActionRowComponentBuilder): component is ButtonBuilder {
 	return component.data.type === ComponentType.Button;
+}
+
+export function isActionButton(action: PaginatedMessageAction): action is PaginatedMessageActionButton {
+	return action.type === ComponentType.Button && action.style !== ButtonStyle.Link;
+}
+
+export function isActionLink(action: PaginatedMessageAction): action is PaginatedMessageActionLink {
+	return action.type === ComponentType.Button && action.style === ButtonStyle.Link;
+}
+
+export function isActionStringMenu(action: PaginatedMessageAction): action is PaginatedMessageActionStringMenu {
+	return action.type === ComponentType.StringSelect;
+}
+
+export function isActionUserMenu(action: PaginatedMessageAction): action is PaginatedMessageActionUserMenu {
+	return action.type === ComponentType.UserSelect;
+}
+
+export function isActionRoleMenu(action: PaginatedMessageAction): action is PaginatedMessageActionRoleMenu {
+	return action.type === ComponentType.RoleSelect;
+}
+
+export function isActionMentionableMenu(action: PaginatedMessageAction): action is PaginatedMessageActionMentionableMenu {
+	return action.type === ComponentType.MentionableSelect;
+}
+
+export function isActionChannelMenu(action: PaginatedMessageAction): action is PaginatedMessageActionChannelMenu {
+	return action.type === ComponentType.ChannelSelect;
 }
 
 export function createPartitionedMessageRow(components: MessageActionRowComponentBuilder[]): PaginatedMessageComponentUnion[] {


### PR DESCRIPTION
There were a few types in the `PaginatedMessage` class which didn't reflect how the class actually resolves things. This brings them in-line with their actual behaviour.

## Changes:

- Allowing `run` on actions to be optional means they can be resolved in interaction handlers rather than just `PaginatedMessage`. This is useful if the button/menu contains a lot of business logic and you want it to have its own piece, or you're passing data in the custom ID.

- `PaginatedMessageMessageOptionsUnion` now omits the `components` property since it was never handled in the first place. Originally, you could pass `components` in the message options without any issues, however the class never used that property and instead resolved the components from `actions`.

- The callback union type is removed from `messages`. This is due to pages _always_ being processed with `resolvePage`, meaning they can never be a callback. The only reason this was on `messages` on the first place was because `pages` from the constructor were immediately placed in the `messages` array without any processing.

    https://github.com/sapphiredev/utilities/blob/db130684ff3c1680f736451361eec80686a783e0/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts#L240-L244

- Added utility functions for type-guarding actions to make editing actions for `updateCurrentPage` easier.

- Cleaned up some `as` usages.

## Breaking changes:

- `updateCurrentPage` components are now resolved from the `actions` property instead of the `components` property. This makes it consistent with all the other page manipulation methods (ie `addPage`, `addPages`, pages provided through the constructor, etc).

    <details>

    <summary>Example: updating a string menu's options</summary>

    ```ts
    actions: [
        {
            type: ComponentType.StringSelect,
            customId: 'custom-id-1',
            options: [
                { label: 'option-1', value: 'value-1' },
                { label: 'option-2', value: 'value-2' },
                { label: 'option-3', value: 'value-3' }
            ]
        },
        {
            type: ComponentType.Button,
            customId: 'custom-id-2',
            style: ButtonStyle.Primary,
            label: 'Button',
            run: async ({ handler }): Promise<void> => {
                const value = Math.floor(Math.random() * 10);

                const page = await handler.getPageOptions(handler.index);

                const action = page?.actions?.at(0);
                if (action && isActionStringMenu(action)) {
                    action.options = [
                        { label: `option-1-${value}`, value: 'value-1' },
                        { label: `option-2-${value}`, value: 'value-2' },
                        { label: `option-3-${value}`, value: 'value-3' }
                    ];
                }

                await handler.updateCurrentPage({
                    ...page,
                    actions: page?.actions ? page.actions : []
                });
            }
        }
    ]
    ```
    </details>

- Removed `getComponents` since it is effectively useless due to the above change.