### PR TITLE
test(sleepSync): use spies for `Date.now()`

### DIFF
--- a/packages/utilities/tests/sleepSync.test.ts
+++ b/packages/utilities/tests/sleepSync.test.ts
@@ -2,15 +2,23 @@ import { sleepSync } from '../src';
 
 describe('sleepSync', () => {
 	test('GIVEN a number of ms THEN return after that time', () => {
-		const start = Date.now();
-		sleepSync(50);
-		expect(Date.now() - start).oneOf([50, 51]);
+		vi.spyOn(Date, 'now') //
+			.mockReturnValueOnce(0)
+			.mockReturnValueOnce(25)
+			.mockReturnValueOnce(50)
+			.mockReturnValueOnce(50);
+
+		expect<undefined>(sleepSync(50)).toBe(undefined);
+		expect(Date.now()).toBe(50);
 	});
 
 	test('GIVEN a number of ms and a value THEN return after that time with the value', () => {
-		const start = Date.now();
-		const value = sleepSync(50, 'test');
-		expect(Date.now() - start).oneOf([50, 51]);
-		expect<string>(value).toBe('test');
+		vi.spyOn(Date, 'now') //
+			.mockReturnValueOnce(0)
+			.mockReturnValueOnce(50)
+			.mockReturnValueOnce(50);
+
+		expect<string>(sleepSync(50, 'test')).toBe('test');
+		expect(Date.now()).toBe(50);
 	});
 });


### PR DESCRIPTION
We're using a spy for `Date.now()` instead of a fake timer. This is because `sleepSync()` does not use timers, but instead checks against `Date.now()`'s value.
