### PR TITLE
fix(tsconfig): set `noEmitHelpers` to false

### DIFF
--- a/packages/discord.js-utilities/src/index.ts
+++ b/packages/discord.js-utilities/src/index.ts
@@ -1,5 +1,3 @@
-import 'tslib';
-
 export * from '@sapphire/discord-utilities';
 export * from './lib/MessagePrompter';
 export * from './lib/PaginatedMessages';

--- a/packages/ts-config/tsconfig.json
+++ b/packages/ts-config/tsconfig.json
@@ -15,7 +15,7 @@
 		"module": "Node16",
 		"moduleResolution": "Node",
 		"newLine": "lf",
-		"noEmitHelpers": true,
+		"noEmitHelpers": false,
 		"noFallthroughCasesInSwitch": true,
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,


### PR DESCRIPTION
This fixes a bug that caused end-users to often need to install `tslib`
manually and add a line `import 'tslib'` at the top of their entrypoint
files because `require('tslib')` is no longer being automatically added by
typescript after setting `"module": "Node16"` in `tsconfig.json`.

Many of our own libraries and those of other users were affected by this
and the better solution is to just emit the helper methods so tslib imports
are no longer needed, and users can use our config without needing extra
steps. If they do still want to not have the helpers emitted, they can
just toggle the option to false and import tslib instead.


Example given `@sapphire/discord.js-utilities`, specifically `dist/index.js`
**before**
```ts
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
require("tslib");
__exportStar(require("@sapphire/discord-utilities"), exports);
__exportStar(require("./lib/MessagePrompter"), exports);
__exportStar(require("./lib/PaginatedMessages"), exports);
__exportStar(require("./lib/builders/MessageBuilder"), exports);
__exportStar(require("./lib/type-guards"), exports);
__exportStar(require("./lib/utilities"), exports);
__exportStar(require("./lib/utility-types"), exports);
//# sourceMappingURL=index.js.map
```

**after**
```ts
"use strict";
var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
    if (k2 === undefined) k2 = k;
    var desc = Object.getOwnPropertyDescriptor(m, k);
    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
      desc = { enumerable: true, get: function() { return m[k]; } };
    }
    Object.defineProperty(o, k2, desc);
}) : (function(o, m, k, k2) {
    if (k2 === undefined) k2 = k;
    o[k2] = m[k];
}));
var __exportStar = (this && this.__exportStar) || function(m, exports) {
    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
};
Object.defineProperty(exports, "__esModule", { value: true });
__exportStar(require("@sapphire/discord-utilities"), exports);
__exportStar(require("./lib/MessagePrompter"), exports);
__exportStar(require("./lib/PaginatedMessages"), exports);
__exportStar(require("./lib/builders/MessageBuilder"), exports);
__exportStar(require("./lib/type-guards"), exports);
__exportStar(require("./lib/utilities"), exports);
__exportStar(require("./lib/utility-types"), exports);
//# sourceMappingURL=index.js.map
```