### PR TITLE
 refactor(utilities): rewrite poll function

### DIFF
--- a/packages/utilities/tests/poll.test.ts
+++ b/packages/utilities/tests/poll.test.ts
@@ -32,7 +32,7 @@ describe('poll', () => {
 	});
 
 	describe('signal', () => {
-		const DOMException = globalThis.DOMException ?? (AbortSignal.abort().constructor as typeof globalThis.DOMException);
+		const DOMException = globalThis.DOMException ?? (AbortSignal.abort().reason.constructor as typeof globalThis.DOMException);
 		test('GIVEN an AbortSignal that is aborted before the first call THEN throws', async () => {
 			const cb = vi.fn(cbRaw);
 			const cbCondition = vi.fn(cbConditionRaw);

--- a/packages/utilities/tests/poll.test.ts
+++ b/packages/utilities/tests/poll.test.ts
@@ -32,6 +32,7 @@ describe('poll', () => {
 	});
 
 	describe('signal', () => {
+		const DOMException = globalThis.DOMException ?? (AbortSignal.abort().constructor as typeof globalThis.DOMException);
 		test('GIVEN an AbortSignal that is aborted before the first call THEN throws', async () => {
 			const cb = vi.fn(cbRaw);
 			const cbCondition = vi.fn(cbConditionRaw);

--- a/packages/utilities/tests/pollSync.test.ts
+++ b/packages/utilities/tests/pollSync.test.ts
@@ -65,7 +65,7 @@ describe('pollSync', () => {
 			.mockReturnValueOnce('fail!')
 			.mockReturnValueOnce('success!');
 
-		const result = pollSync(mockFunction, (result) => result === 'success!', oneMillisecond, oneMinute, true);
+		const result = pollSync(mockFunction, (result) => result === 'success!', oneMillisecond, oneMinute, { verbose: true });
 
 		expect(result).toBe('success!');
 		expect(mockFunction).toBeCalledTimes(3);


### PR DESCRIPTION
Using `AbortSignal`, added more options to further customize `poll`'s behaviour.