### PR TITLE
feat(PaginatedMessage): improve `@discordjs/builders` support

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -2,7 +2,7 @@ import { isFunction } from '@sapphire/utilities';
 import { EmbedBuilder, Message, User } from 'discord.js';
 import { MessageBuilder } from '../builders/MessageBuilder';
 import type { AnyInteractableInteraction } from '../utility-types';
-import { PaginatedMessage } from './PaginatedMessage';
+import { PaginatedMessage, type EmbedResolvable } from './PaginatedMessage';
 import type { PaginatedMessageResolvedPage } from './PaginatedMessageTypes';
 
 /**
@@ -43,13 +43,13 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 		return this.addPage(() => ({ content }));
 	}
 
-	public override addPageEmbed(embed: EmbedBuilder | ((builder: EmbedBuilder) => EmbedBuilder)): this {
+	public override addPageEmbed(embed: EmbedResolvable | ((builder: EmbedBuilder) => EmbedResolvable)): this {
 		return this.addPage(() => ({ embeds: typeof embed === 'function' ? [embed(new EmbedBuilder())] : [embed] }));
 	}
 
 	public override addPageEmbeds(
 		embeds:
-			| EmbedBuilder[]
+			| EmbedResolvable[]
 			| ((
 					embed1: EmbedBuilder,
 					embed2: EmbedBuilder,
@@ -61,7 +61,7 @@ export class LazyPaginatedMessage extends PaginatedMessage {
 					embed8: EmbedBuilder,
 					embed9: EmbedBuilder,
 					embed10: EmbedBuilder
-			  ) => EmbedBuilder[])
+			  ) => EmbedResolvable[])
 	): this {
 		return this.addPage(() => {
 			let processedEmbeds = isFunction(embeds)

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/LazyPaginatedMessage.ts
@@ -2,8 +2,8 @@ import { isFunction } from '@sapphire/utilities';
 import { EmbedBuilder, Message, User } from 'discord.js';
 import { MessageBuilder } from '../builders/MessageBuilder';
 import type { AnyInteractableInteraction } from '../utility-types';
-import { PaginatedMessage, type EmbedResolvable } from './PaginatedMessage';
-import type { PaginatedMessageResolvedPage } from './PaginatedMessageTypes';
+import { PaginatedMessage } from './PaginatedMessage';
+import type { EmbedResolvable, PaginatedMessageResolvedPage } from './PaginatedMessageTypes';
 
 /**
  * This is a LazyPaginatedMessage. Instead of resolving all pages that are functions on {@link PaginatedMessage.run} will resolve when requested.

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedFieldMessageEmbed.ts
@@ -1,6 +1,7 @@
 import { isFunction, isNullish, isNullishOrEmpty } from '@sapphire/utilities';
-import { EmbedBuilder, isJSONEncodable, type EmbedData, type APIEmbed } from 'discord.js';
-import { PaginatedMessage, type EmbedResolvable } from './PaginatedMessage';
+import { EmbedBuilder, isJSONEncodable, type APIEmbed, type EmbedData } from 'discord.js';
+import { PaginatedMessage } from './PaginatedMessage';
+import type { EmbedResolvable } from './PaginatedMessageTypes';
 
 /**
  * This is a utility of {@link PaginatedMessage}, except it exclusively adds pagination inside a field of an embed.
@@ -148,14 +149,14 @@ export class PaginatedFieldMessageEmbed<T> extends PaginatedMessage {
 	private generatePages() {
 		const template = this.embedTemplate;
 		for (let i = 0; i < this.totalPages; i++) {
-			const fields = isNullishOrEmpty(template.fields) ? [] : [...template.fields];
-			const embed = new EmbedBuilder(template);
-			if (fields.length > 0) embed.setFields();
-			if (isNullish(template.color)) embed.setColor('Random');
+			const clonedTemplate = new EmbedBuilder(template);
+			const fieldsClone = isNullishOrEmpty(template.fields) ? [] : [...template.fields];
+			if (fieldsClone.length > 0) clonedTemplate.setFields();
+			if (isNullish(template.color)) clonedTemplate.setColor('Random');
 
 			const data = this.paginateArray(this.items, i, this.itemsPerPage);
 			this.addPage({
-				embeds: [embed.addFields({ name: this.fieldTitle, value: data.join('\n'), inline: false }, ...fields)]
+				embeds: [clonedTemplate.addFields({ name: this.fieldTitle, value: data.join('\n'), inline: false }, ...fieldsClone)]
 			});
 		}
 	}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -1,5 +1,5 @@
 import { Time } from '@sapphire/duration';
-import { deepClone, isFunction, isNullish, isObject } from '@sapphire/utilities';
+import { deepClone, isFunction, isNullish, isObject, type Awaitable } from '@sapphire/utilities';
 import {
 	ButtonBuilder,
 	ButtonStyle,
@@ -55,6 +55,8 @@ import {
 	isMessageUserSelectInteractionData,
 	safelyReplyToInteraction
 } from './utils';
+
+export type EmbedResolvable = JSONEncodable<APIEmbed> | APIEmbed;
 
 /**
  * This is a {@link PaginatedMessage}, a utility to paginate messages (usually embeds).
@@ -626,7 +628,7 @@ export class PaginatedMessage {
 	 * 	.addPageEmbed(embed);
 	 * ```
 	 */
-	public addPageEmbed(embed: EmbedBuilder | ((embed: EmbedBuilder) => EmbedBuilder)): this {
+	public addPageEmbed(embed: EmbedResolvable | ((embed: EmbedBuilder) => EmbedResolvable)): this {
 		return this.addPage({ embeds: isFunction(embed) ? [embed(new EmbedBuilder())] : [embed] });
 	}
 
@@ -649,7 +651,7 @@ export class PaginatedMessage {
 	 * });
 	 * ```
 	 */
-	public addAsyncPageEmbed(embed: EmbedBuilder | ((builder: EmbedBuilder) => Promise<EmbedBuilder>)): this {
+	public addAsyncPageEmbed(embed: EmbedResolvable | ((builder: EmbedBuilder) => Awaitable<EmbedResolvable>)): this {
 		return this.addPage(async () => ({ embeds: isFunction(embed) ? [await embed(new EmbedBuilder())] : [embed] }));
 	}
 
@@ -702,7 +704,7 @@ export class PaginatedMessage {
 	 */
 	public addPageEmbeds(
 		embeds:
-			| EmbedBuilder[]
+			| EmbedResolvable[]
 			| ((
 					embed1: EmbedBuilder,
 					embed2: EmbedBuilder,
@@ -714,7 +716,7 @@ export class PaginatedMessage {
 					embed8: EmbedBuilder,
 					embed9: EmbedBuilder,
 					embed10: EmbedBuilder
-			  ) => EmbedBuilder[])
+			  ) => EmbedResolvable[])
 	): this {
 		let processedEmbeds = isFunction(embeds)
 			? embeds(
@@ -793,7 +795,7 @@ export class PaginatedMessage {
 	 */
 	public addAsyncPageEmbeds(
 		embeds:
-			| EmbedBuilder[]
+			| EmbedResolvable[]
 			| ((
 					embed1: EmbedBuilder,
 					embed2: EmbedBuilder,
@@ -805,7 +807,7 @@ export class PaginatedMessage {
 					embed8: EmbedBuilder,
 					embed9: EmbedBuilder,
 					embed10: EmbedBuilder
-			  ) => Promise<EmbedBuilder[]>)
+			  ) => Awaitable<EmbedResolvable[]>)
 	): this {
 		return this.addPage(async () => {
 			let processedEmbeds = isFunction(embeds)
@@ -1392,24 +1394,20 @@ export class PaginatedMessage {
 		const embedsWithFooterApplied = deepClone(message.embeds);
 
 		const idx = embedsWithFooterApplied.length - 1;
-		const lastEmbed = embedsWithFooterApplied[idx];
-		if (lastEmbed) {
-			const jsonTemplateEmbed = isJSONEncodable(this.template.embeds?.[idx] ?? this.template.embeds?.[0])
-				? ((this.template.embeds?.[idx] ?? this.template.embeds?.[0]) as JSONEncodable<APIEmbed> | undefined)?.toJSON()
-				: ((this.template.embeds?.[idx] ?? this.template.embeds?.[0]) as APIEmbed | undefined);
+		if (embedsWithFooterApplied.length > 0) {
+			let lastEmbed = embedsWithFooterApplied[idx];
+			const templateEmbed = this.template.embeds?.[idx] ?? this.template.embeds?.[0];
+			const jsonTemplateEmbed = isJSONEncodable(templateEmbed) ? templateEmbed.toJSON() : templateEmbed;
 
 			if (isJSONEncodable(lastEmbed)) {
-				const casted = lastEmbed as EmbedBuilder;
-				casted.data.footer ??= { text: jsonTemplateEmbed?.footer?.text ?? '' };
-				casted.data.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
-					casted.data.footer.text ? ` ${this.embedFooterSeparator} ${casted.data.footer.text}` : ''
-				}`;
-			} else {
-				lastEmbed.footer ??= { text: jsonTemplateEmbed?.footer?.text ?? '' };
-				lastEmbed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
-					lastEmbed.footer.text ? ` ${this.embedFooterSeparator} ${lastEmbed.footer.text}` : ''
-				}`;
+				lastEmbed = lastEmbed.toJSON();
+				embedsWithFooterApplied[idx] = lastEmbed;
 			}
+
+			lastEmbed.footer ??= { text: jsonTemplateEmbed?.footer?.text ?? '' };
+			lastEmbed.footer.text = `${this.pageIndexPrefix ? `${this.pageIndexPrefix} ` : ''}${index + 1} / ${this.pages.length}${
+				lastEmbed.footer.text ? ` ${this.embedFooterSeparator} ${lastEmbed.footer.text}` : ''
+			}`;
 		}
 
 		return { ...message, embeds: embedsWithFooterApplied };
@@ -1727,13 +1725,13 @@ export class PaginatedMessage {
 		allowedMentions: { users: [], roles: [] }
 	});
 
-	private static resolveTemplate(template?: EmbedBuilder | BaseMessageOptions): BaseMessageOptions {
+	private static resolveTemplate(template?: JSONEncodable<APIEmbed> | BaseMessageOptions): BaseMessageOptions {
 		if (template === undefined) {
 			return {};
 		}
 
-		if (template instanceof EmbedBuilder) {
-			return { embeds: [template] };
+		if (isJSONEncodable(template)) {
+			return { embeds: [template.toJSON()] };
 		}
 
 		return template;

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -31,6 +31,7 @@ import { MessageBuilder } from '../builders/MessageBuilder';
 import { isAnyInteraction, isGuildBasedChannel, isMessageInstance, isStageChannel } from '../type-guards';
 import type { AnyInteractableInteraction } from '../utility-types';
 import type {
+	EmbedResolvable,
 	PaginatedMessageAction,
 	PaginatedMessageComponentUnion,
 	PaginatedMessageEmbedResolvable,
@@ -55,8 +56,6 @@ import {
 	isMessageUserSelectInteractionData,
 	safelyReplyToInteraction
 } from './utils';
-
-export type EmbedResolvable = JSONEncodable<APIEmbed> | APIEmbed;
 
 /**
  * This is a {@link PaginatedMessage}, a utility to paginate messages (usually embeds).

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageEmbedFields.ts
@@ -1,7 +1,8 @@
 import { EmbedLimits } from '@sapphire/discord-utilities';
 import { isFunction, isNullishOrEmpty } from '@sapphire/utilities';
-import { EmbedBuilder, type APIEmbed, type EmbedData, type EmbedField, isJSONEncodable } from 'discord.js';
-import { PaginatedMessage, type EmbedResolvable } from './PaginatedMessage';
+import { EmbedBuilder, isJSONEncodable, type APIEmbed, type EmbedData, type EmbedField } from 'discord.js';
+import { PaginatedMessage } from './PaginatedMessage';
+import type { EmbedResolvable } from './PaginatedMessageTypes';
 
 /**
  * This is a utility of {@link PaginatedMessage}, except it exclusively paginates the fields of an embed.
@@ -116,15 +117,15 @@ export class PaginatedMessageEmbedFields extends PaginatedMessage {
 	private generatePages(): void {
 		const template = this.embedTemplate;
 		for (let i = 0; i < this.totalPages; i++) {
-			const fields = isNullishOrEmpty(template.fields) ? [] : [...template.fields];
-			const embed = new EmbedBuilder(template);
-			if (fields.length > 0) embed.setFields();
+			const clonedTemplate = new EmbedBuilder(template);
+			const fieldsClone = isNullishOrEmpty(template.fields) ? [] : [...template.fields];
+			if (fieldsClone.length > 0) clonedTemplate.setFields();
 
-			if (!embed.data.color) embed.setColor('Random');
+			if (!clonedTemplate.data.color) clonedTemplate.setColor('Random');
 
-			const data = this.paginateArray(this.items, i, this.itemsPerPage - fields.length);
+			const data = this.paginateArray(this.items, i, this.itemsPerPage - fieldsClone.length);
 			this.addPage({
-				embeds: [embed.addFields(...data, ...fields)]
+				embeds: [clonedTemplate.addFields(...data, ...fieldsClone)]
 			});
 		}
 	}

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -1,6 +1,7 @@
 import type { Awaitable } from '@sapphire/utilities';
 import type {
 	APIActionRowComponent,
+	APIEmbed,
 	APIMessage,
 	APIMessageActionRowComponent,
 	ActionRowComponentOptions,
@@ -310,3 +311,5 @@ export type PaginatedMessageStopReasons =
 	| 'limit'
 	| 'componentLimit'
 	| 'userLimit';
+
+export type EmbedResolvable = JSONEncodable<APIEmbed> | APIEmbed;


### PR DESCRIPTION
List of changes:
- feat(PaginatedMessage): add `JSONEncodable<APIEmbed>` support
- feat(PaginatedFieldMessageEmbed): add `JSONEncodable<APIEmbed>` support
- feat(PaginatedMessageEmbedFields): add `JSONEncodable<APIEmbed>` support
- refactor(LazyPaginatedMessage): remove useless overriding methods
- refactor(PaginatedFieldMessageEmbed): make template always `APIEmbed`
- refactor(PaginatedMessageEmbedFields): make template always `APIEmbed`
