### PR TITLE
docs(discord.js-utilities): update discord.js.org links

### DIFF
--- a/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
@@ -132,7 +132,7 @@ export class MessagePrompter<S extends keyof StrategyReturns = 'confirm'> {
 	/**
 	 * This executes the {@link MessagePrompter} and sends the message.
 	 * @param channel The channel to use.
-	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/#/docs/main/stable/typedef/CollectorFilter CollectorFilter} predicate callback.
+	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/docs/packages/discord.js/main/CollectorFilter:TypeAlias CollectorFilter} predicate callback.
 	 */
 	public run<Filter extends S extends keyof StrategyFilters ? StrategyFilters[S] : unknown[]>(
 		channel: MessagePrompterChannelTypes,

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterConfirmStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterConfirmStrategy.ts
@@ -31,7 +31,7 @@ export class MessagePrompterConfirmStrategy extends MessagePrompterBaseStrategy 
 	 * This executes the {@link MessagePrompter} and sends the message if {@link IMessagePrompterOptions.type} equals confirm.
 	 * The handler will wait for one (1) reaction.
 	 * @param channel The channel to use.
-	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/#/docs/main/stable/typedef/CollectorFilter CollectorFilter} predicate callback.
+	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/docs/packages/discord.js/main/CollectorFilter:TypeAlias CollectorFilter} predicate callback.
 	 * @returns A promise that resolves to a boolean denoting the value of the input (`true` for yes, `false` for no).
 	 */
 	public override async run(

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterMessageStrategy.ts
@@ -20,7 +20,7 @@ export class MessagePrompterMessageStrategy extends MessagePrompterBaseStrategy 
 	 * This executes the {@link MessagePrompter} and sends the message if {@link IMessagePrompterOptions.type} equals message.
 	 * The handler will wait for one (1) message.
 	 * @param channel The channel to use.
-	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/#/docs/main/stable/typedef/CollectorFilter CollectorFilter} predicate callback.
+	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/docs/packages/discord.js/main/CollectorFilter:TypeAlias CollectorFilter} predicate callback.
 	 * @returns A promise that resolves to the message object received.
 	 */
 	public override async run(

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterNumberStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterNumberStrategy.ts
@@ -35,7 +35,7 @@ export class MessagePrompterNumberStrategy extends MessagePrompterBaseStrategy i
 	 * This executes the {@link MessagePrompter} and sends the message if {@link IMessagePrompterOptions.type} equals number.
 	 * The handler will wait for one (1) reaction.
 	 * @param channel The channel to use.
-	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/#/docs/main/stable/typedef/CollectorFilter CollectorFilter} predicate callback.
+	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/docs/packages/discord.js/main/CollectorFilter:TypeAlias CollectorFilter} predicate callback.
 	 * @returns A promise that resolves to the selected number within the range.
 	 */
 	public async run(

--- a/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterReactionStrategy.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/strategies/MessagePrompterReactionStrategy.ts
@@ -25,7 +25,7 @@ export class MessagePrompterReactionStrategy extends MessagePrompterBaseStrategy
 	 * This executes the {@link MessagePrompterReactionStrategy} and sends the message.
 	 * The handler will wait for one (1) reaction.
 	 * @param channel The channel to use.
-	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/#/docs/main/stable/typedef/CollectorFilter CollectorFilter} predicate callback.
+	 * @param authorOrFilter An author object to validate or a {@linkplain https://discord.js.org/docs/packages/discord.js/main/CollectorFilter:TypeAlias CollectorFilter} predicate callback.
 	 * @returns A promise that resolves to the reaction object.
 	 */
 	public async run(

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -63,11 +63,11 @@ import {
  * @remark Please note that for {@link PaginatedMessage} to work in DMs to your client, you need to add the `'CHANNEL'` partial to your `client.options.partials`.
  * Message based commands can always be used in DMs, whereas Chat Input interactions can only be used in DMs when they are registered globally.
  *
- * {@link PaginatedMessage} uses {@linkplain https://discord.js.org/#/docs/main/stable/typedef/MessageComponent MessageComponent} buttons that perform the specified action when clicked.
+ * {@link PaginatedMessage} uses {@linkplain https://discord.js.org/docs/packages/discord.js/main/MessageComponent:TypeAlias MessageComponent} buttons that perform the specified action when clicked.
  * You can either use your own actions or the {@link PaginatedMessage.defaultActions}.
  * {@link PaginatedMessage.defaultActions} is also static so you can modify these directly.
  *
- * {@link PaginatedMessage} also uses pages via {@linkplain https://discord.js.org/#/docs/main/stable/class/Message Messages}.
+ * {@link PaginatedMessage} also uses pages via {@linkplain https://discord.js.org/docs/packages/discord.js/main/Message:Class Messages}.
  *
  * @example
  * ```typescript
@@ -1596,7 +1596,7 @@ export class PaginatedMessage {
 	public static stopPaginatedMessageCustomIds = ['@sapphire/paginated-messages.stop'];
 
 	/**
-	 * The reasons sent by {@linkplain https://discord.js.org/#/docs/main/stable/class/InteractionCollector?scrollTo=e-end InteractionCollector#end}
+	 * The reasons sent by {@linkplain https://discord.js.org/docs/packages/discord.js/main/InteractionCollector:Class#end InteractionCollector#end}
 	 * event when the message (or its owner) has been deleted.
 	 */
 	public static deletionStopReasons = ['messageDelete', 'channelDelete', 'guildDelete'];


### PR DESCRIPTION
Now that the rewrite is up and live, I updated the links. `@discord.js-utilities` was the only package referencing djs's docs, so only one package was updated.