### PR TITLE
feat(tryParseJSON): support `replacer` argument

### DIFF
--- a/packages/utilities/src/lib/tryParseJSON.ts
+++ b/packages/utilities/src/lib/tryParseJSON.ts
@@ -1,10 +1,11 @@
 /**
  * Try parse a stringified JSON string.
- * @param value The value to parse
+ * @param value The string to parse as JSON.
+ * @param reviver A function that transforms the results. This function is recursively called for each member of the object.
  */
-export function tryParseJSON(value: string): object | string | number {
+export function tryParseJSON(value: string, reviver?: (this: object, key: string, value: unknown) => unknown): object | string | number {
 	try {
-		return JSON.parse(value);
+		return JSON.parse(value, reviver);
 	} catch (err) {
 		return value;
 	}

--- a/packages/utilities/src/lib/tryParseJSON.ts
+++ b/packages/utilities/src/lib/tryParseJSON.ts
@@ -3,7 +3,10 @@
  * @param value The string to parse as JSON.
  * @param reviver A function that transforms the results. This function is recursively called for each member of the object.
  */
-export function tryParseJSON(value: string, reviver?: (this: object, key: string, value: unknown) => unknown): object | string | number {
+export function tryParseJSON(
+	value: string,
+	reviver?: (this: object, key: string, value: unknown) => unknown
+): object | string | number | boolean | null {
 	try {
 		return JSON.parse(value, reviver);
 	} catch (err) {

--- a/packages/utilities/tests/tryParseJSON.test.ts
+++ b/packages/utilities/tests/tryParseJSON.test.ts
@@ -7,6 +7,14 @@ describe('tryParseJSON', () => {
 		expect(tryParseJSON(source)).toEqual(expected);
 	});
 
+	test('GIVEN basic with replacer THEN returns expected', () => {
+		const source = '{"a":4,"b":6}';
+		const expected = { a: '4', b: '6' };
+		const replacer = vi.fn((_key: string, value: unknown) => (typeof value === 'number' ? String(value) : value));
+		expect(tryParseJSON(source, replacer)).toEqual(expected);
+		expect(replacer).toHaveBeenCalledTimes(3);
+	});
+
 	test('GIVEN invalid THEN returns expected', () => {
 		const source = '{"a":4,"b:6}';
 		const expected = '{"a":4,"b:6}';


### PR DESCRIPTION
Just like `tryParseJSON`'s types are hardened in relation to the `JSON.parse` counterpart, the `replacer` function is also hardened.