### PR TITLE
fix(tsconfig): add DOM types to lib

### DIFF
--- a/packages/ts-config/src/tsconfig.json
+++ b/packages/ts-config/src/tsconfig.json
@@ -8,7 +8,7 @@
 		"esModuleInterop": true,
 		"importHelpers": false,
 		"incremental": true,
-		"lib": ["esnext"],
+		"lib": ["ESNext", "DOM"],
 		"module": "Node16",
 		"moduleResolution": "Node16",
 		"newLine": "lf",


### PR DESCRIPTION
Too often does it happen that @types/node does not expose everything that is officially available in the Global scope to the Global scope. A perfect example of this is that without DOM types when compiling a project that uses @sapphire/fetch you get the error:
```
node_modules/@sapphire/fetch/dist/cjs/index.d.ts:264:12 - error TS2304: Cannot find name 'BodyInit'.

264     body?: BodyInit | Record<any, any>;
               ~~~~~~~~


Found 1 error in node_modules/@sapphire/fetch/dist/cjs/index.d.ts:264
```

And this is just one possible example among others. As Node and browsers inch ever close to one another in terms of API this problem is only going to increase I think.