### PR TITLE
fix(fetch): add additional reference lib comment

### DIFF
--- a/packages/fetch/src/lib/types.ts
+++ b/packages/fetch/src/lib/types.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
 /**
  * The supported return types for the `fetch` method
  */


### PR DESCRIPTION
This is faintly related to #694, however, this time the issue is fixed from the @sapphire/fetch side of things. The way tsup is bundling our package is by putting the content from `src/lib/types.ts` (interfaces and enums) at the top of the `index.d.ts`/`index.d.mts` file without hoisting the reference lib comment to the top. TS then sees DOM code being used _above_ the reference lib comment and says that the DOM code is not available when compiling.

By adding a reference lib comment in `types.ts` it will be put at the top of the `index.d.ts`/`index.d.mts` file and the issue is resolved.