### PR TITLE
fix(PaginatedMessage): fixed link buttons not properly being added

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessage.ts
@@ -46,6 +46,7 @@ import type {
 } from './PaginatedMessageTypes';
 import {
 	actionIsButtonOrMenu,
+	actionIsLinkButton,
 	createPartitionedMessageRow,
 	isMessageButtonInteractionData,
 	isMessageChannelSelectInteractionData,
@@ -704,10 +705,10 @@ export class PaginatedMessage {
 	 * @see {@link PaginatedMessage.setActions} for examples on how to structure the action.
 	 */
 	public addAction(action: PaginatedMessageAction): this {
-		if (actionIsButtonOrMenu(action)) {
-			this.actions.set(action.customId, action);
-		} else {
+		if (actionIsLinkButton(action)) {
 			this.actions.set(action.url, action);
+		} else if (actionIsButtonOrMenu(action)) {
+			this.actions.set(action.customId, action);
 		}
 
 		return this;
@@ -1204,10 +1205,10 @@ export class PaginatedMessage {
 			this.pageActions[index] = new Map<string, PaginatedMessageAction>();
 		}
 
-		if (actionIsButtonOrMenu(action)) {
-			this.pageActions[index]!.set(action.customId, action);
-		} else {
+		if (actionIsLinkButton(action)) {
 			this.pageActions[index]!.set(action.url, action);
+		} else if (actionIsButtonOrMenu(action)) {
+			this.pageActions[index]!.set(action.customId, action);
 		}
 
 		return this;

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -46,6 +46,15 @@ export function actionIsButtonOrMenu(action: PaginatedMessageAction): action is 
 }
 
 /**
+ * Checks if a PaginatedMessageAction is a button with {@link ButtonStyle.Link style `link`}.
+ * @param action The PaginatedMessageAction to check.
+ * @returns `true` if the action is a button with {@link ButtonStyle.Link style `link`}, `false` otherwise.
+ */
+export function actionIsLinkButton(action: PaginatedMessageAction): action is PaginatedMessageActionLink {
+	return action.type === ComponentType.Button && action.style === ButtonStyle.Link;
+}
+
+/**
  * Checks if the given interaction is a button interaction.
  * @param interaction - The interaction to check.
  * @returns True if the interaction is a button interaction, false otherwise.


### PR DESCRIPTION
Previously link buttons didnt get added properly when using `setActions`/`addAction`/`addActions` because we didn't properly check for Link style buttons.

Despite adding 3 buttons this caused PaginatedMessages such as:
![image](https://github.com/sapphiredev/utilities/assets/4019718/296e025c-7436-46c6-8fec-976d34eb119e)

After applying these changes it is correctly instead:
![image](https://github.com/sapphiredev/utilities/assets/4019718/a599f171-e1a9-46f0-b863-a853520ebd3c)
