### PR TITLE
refactor(PaginatedMessage): always put link buttons below select menus

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -13,7 +13,8 @@ import {
 	type MessageActionRowComponentBuilder,
 	type RoleSelectMenuComponentData,
 	type StringSelectMenuComponentData,
-	type UserSelectMenuComponentData
+	type UserSelectMenuComponentData,
+	type APIButtonComponent
 } from 'discord.js';
 import { isAnyInteractableInteraction, isMessageInstance } from '../type-guards';
 import type {
@@ -179,12 +180,13 @@ export function isActionChannelMenu(action: PaginatedMessageAction): action is P
 export function createPartitionedMessageRow(components: MessageActionRowComponentBuilder[]): PaginatedMessageComponentUnion[] {
 	// Partition the components into two groups: buttons and select menus
 	const [messageButtons, selectMenus] = partition(components, isButtonComponentBuilder);
+	const [actionButtons, linkButtons] = partition(messageButtons, (value) => (value.data as Partial<APIButtonComponent>).style !== ButtonStyle.Link);
 
 	// Chunk the button components in sets of 5, the maximum of 1 ActionRowBuilder
-	const chunkedButtonComponents = chunk(messageButtons, 5);
+	const chunkedActionButtonComponents = chunk(actionButtons, 5);
 
 	// Map all the button components to ActionRowBuilders
-	const messageButtonActionRows = chunkedButtonComponents.map((componentsChunk) =>
+	const messageActionButtonActionRows = chunkedActionButtonComponents.map((componentsChunk) =>
 		new ActionRowBuilder() //
 			.setComponents(componentsChunk)
 	);
@@ -195,7 +197,16 @@ export function createPartitionedMessageRow(components: MessageActionRowComponen
 			.setComponents(component)
 	);
 
-	return [...messageButtonActionRows, ...selectMenuActionRows].map((actionRow) =>
+	// Chunk the button components in sets of 5, the maximum of 1 ActionRowBuilder
+	const chunkedLinkButtonComponents = chunk(linkButtons, 5);
+
+	// Map all the button components to ActionRowBuilders
+	const messageLinkButtonActionRows = chunkedLinkButtonComponents.map((componentsChunk) =>
+		new ActionRowBuilder() //
+			.setComponents(componentsChunk)
+	);
+
+	return [...messageActionButtonActionRows, ...selectMenuActionRows, ...messageLinkButtonActionRows].map((actionRow) =>
 		actionRow.toJSON()
 	) as APIActionRowComponent<APIMessageActionRowComponent>[];
 }


### PR DESCRIPTION
This is a side effect of sorts of #698. Previously this issue wasn't really brought to light because Link buttons didn't get added properly. While it's purely subjective, I think link buttons should go below the select menu. This way the order is consistent across PaginatedMessages:
1. Action buttons
1. Select menus
1. Link buttons