### PR TITLE
feat(utilities): expose `Arr` to the docs

### DIFF
--- a/packages/utilities/src/lib/types.ts
+++ b/packages/utilities/src/lib/types.ts
@@ -60,7 +60,6 @@ export type ArgumentTypes<F extends (...args: any[]) => unknown> = F extends (..
 
 /**
  * A readonly array of any values.
- * @private
  */
 export type Arr = readonly any[];
 

--- a/packages/utilities/src/lib/types.ts
+++ b/packages/utilities/src/lib/types.ts
@@ -61,17 +61,17 @@ export type ArgumentTypes<F extends (...args: any[]) => unknown> = F extends (..
 /**
  * A readonly array of any values.
  */
-export type Arr = readonly any[];
+export type AnyReadonlyArray = readonly any[];
 
 /**
  * A generic constructor with parameters
  */
-export type Ctor<A extends Arr = readonly any[], R = any> = new (...args: A) => R;
+export type Ctor<A extends AnyReadonlyArray = readonly any[], R = any> = new (...args: A) => R;
 
 /**
  * A generic abstract constructor with parameters
  */
-export type AbstractCtor<A extends Arr = readonly any[], R = any> = abstract new (...args: A) => R;
+export type AbstractCtor<A extends AnyReadonlyArray = readonly any[], R = any> = abstract new (...args: A) => R;
 
 /**
  * A generic constructor without parameters


### PR DESCRIPTION
Fixes this warning:

> [warning] `Arr`, defined in
> `./projects/utilities/packages/utilities/src/lib/types.ts`,
> is referenced by `AbstractCtor.A` but not included in the documentation