### PR TITLE
perf: implement fast word writing

### DIFF
--- a/packages/string-store/tests/lib/Schema.test.ts
+++ b/packages/string-store/tests/lib/Schema.test.ts
@@ -377,14 +377,14 @@ describe('Schema', () => {
 
 	describe('serialization', () => {
 		test('GIVEN a schema with a boolean property THEN it serializes correctly', () => {
-			const buffer = new UnalignedUint16Array(2);
-			const schema = new Schema(4).boolean('a');
+			const buffer = new UnalignedUint16Array(3);
+			const schema = new Schema(4).boolean('a').int16('b');
 
-			schema.serialize(buffer, { a: true });
-			expect(buffer.toArray()).toEqual(new Uint16Array([4, 1]));
+			schema.serialize(buffer, { a: true, b: 15234 });
+			expect(buffer.toArray()).toEqual(new Uint16Array([4, 1 + (15234 << 1), 0]));
 
 			const value = schema.deserialize(buffer, 16);
-			expect<{ a: boolean }>(value).toEqual({ a: true });
+			expect<{ a: boolean }>(value).toEqual({ a: true, b: 15234 });
 		});
 	});
 

--- a/packages/string-store/tests/lib/UnalignedUint16Array.test.ts
+++ b/packages/string-store/tests/lib/UnalignedUint16Array.test.ts
@@ -151,7 +151,13 @@ describe('UnalignedUint16Array', () => {
 		expect(buffer.readFloat64(0)).toBe(0.5);
 	});
 
-	test('GIVEN an instance with insufficient space THEN it throws', () => {
+	test('GIVEN an instance with insufficient space (write bit by bit) THEN it throws', () => {
+		const buffer = new UnalignedUint16Array(1);
+		buffer.writeInt16(1);
+		expect(() => buffer.writeBit(1)).toThrowError('The buffer is full');
+	});
+
+	test('GIVEN an instance with insufficient space (write word by word) THEN it throws', () => {
 		const buffer = new UnalignedUint16Array(1);
 		expect(() => buffer.writeInt32(1)).toThrowError('The buffer is full');
 	});


### PR DESCRIPTION
Writing values over 16 bits bit by bit is inefficient, especially when it's the word size of the buffer. This PR optimizes the code by writing the value in at most two operations, significantly improving the performance for large values.

This makes writing operations the size of a word or larger do 16 times fewer operations.
