### PR TITLE
refactor(SchemaStore)!: introduce `serializeRaw`

### DIFF
--- a/packages/string-store/src/lib/schema/SchemaStore.ts
+++ b/packages/string-store/src/lib/schema/SchemaStore.ts
@@ -59,9 +59,20 @@ export class SchemaStore<Entries extends object = object> {
 	 *
 	 * @param id The id of the schema to use for serialization
 	 * @param value The value to serialize
+	 * @returns The serialized string
+	 */
+	public serialize<const Id extends KeyOfStore<this>>(id: Id, value: SerializeValue<Entries[Id] & object>): string {
+		return this.serializeRaw(id, value).toString();
+	}
+
+	/**
+	 * Serializes a value using the schema with the given id
+	 *
+	 * @param id The id of the schema to use for serialization
+	 * @param value The value to serialize
 	 * @returns The serialized buffer
 	 */
-	public serialize<const Id extends KeyOfStore<this>>(id: Id, value: SerializeValue<Entries[Id] & object>): UnalignedUint16Array {
+	public serializeRaw<const Id extends KeyOfStore<this>>(id: Id, value: SerializeValue<Entries[Id] & object>): UnalignedUint16Array {
 		const schema = this.get(id) as Schema<Id, object>;
 		const buffer = new UnalignedUint16Array(schema.totalBitSize ?? this.defaultMaximumArrayLength);
 		schema.serialize(buffer, value);

--- a/packages/string-store/tests/lib/SchemaStore.test.ts
+++ b/packages/string-store/tests/lib/SchemaStore.test.ts
@@ -28,23 +28,26 @@ describe('SchemaStore', () => {
 		test('GIVEN a schema and a value THEN it serializes and deserializes the buffer correctly', () => {
 			const store = new SchemaStore(10).add(new Schema(2).string('name').float64('height'));
 
-			const buffer = store.serialize(2, { name: 'Mario', height: 1.8 });
+			const buffer = store.serializeRaw(2, { name: 'Mario', height: 1.8 });
 			const deserialized = store.deserialize(buffer);
 			expect<{ id: 2; data: { height: number } }>(deserialized).toEqual({ id: 2, data: { name: 'Mario', height: 1.8 } });
 
 			expect<2>(store.getIdentifier(buffer)).toBe(2);
 			expect<2>(store.getIdentifier(buffer.toString())).toBe(2);
+
+			expectTypeOf(buffer).toEqualTypeOf<UnalignedUint16Array>();
 		});
 
 		test('GIVEN a schema and a value THEN it serializes and deserializes the binary string correctly', () => {
 			const store = new SchemaStore(10).add(new Schema(2).string('name').float64('height'));
 
 			const buffer = store.serialize(2, { name: 'Mario', height: 1.8 });
-			const deserialized = store.deserialize(buffer.toString());
+			const deserialized = store.deserialize(buffer);
 			expect<{ id: 2; data: { height: number } }>(deserialized).toEqual({ id: 2, data: { name: 'Mario', height: 1.8 } });
 
 			expect<2>(store.getIdentifier(buffer)).toBe(2);
-			expect<2>(store.getIdentifier(buffer.toString())).toBe(2);
+
+			expectTypeOf(buffer).toEqualTypeOf<string>();
 		});
 
 		test('GIVEN a schema with a constant THEN it serializes and deserializes the buffer correctly', () => {


### PR DESCRIPTION
BREAKING CHANGE: `serialize` no longer returns an `UnalignedUint16Array`, if you desire the old behaviour, use `serializeRaw`
