### PR TITLE
docs: update documentation link for usage examples

### DIFF
--- a/packages/result/README.md
+++ b/packages/result/README.md
@@ -36,7 +36,7 @@ npm install @sapphire/result
 
 **Note 1:** While this section uses `require`, the imports match 1:1 with ESM imports. For example `const { Result } = require('@sapphire/result')` equals `import { Result } from '@sapphire/result'`.
 
-**Note 2:** For more thorough examples check out the generated documentation on [our website here](https://www.sapphirejs.dev/docs/Documentation/api-utilities/@sapphire/result/interfaces/IResult)
+**Note 2:** For more thorough examples check out the generated documentation on [our website here](https://www.sapphirejs.dev/docs/Documentation/api-utilities/@sapphire/result/)
 
 ### Wrapping synchronous `try-catch` blocks
 


### PR DESCRIPTION
This pull request updates the documentation in the `packages/result/README.md` file to fix a broken link to the generated API documentation for the `@sapphire/result` package. Resolves #882.

Documentation updates:

* Corrected the link to the generated documentation by removing the outdated `/interfaces/IResult` path, ensuring the link now points to the correct base documentation page.