### PR TITLE
ci(auto-updater): build prettier config

### DIFF
--- a/.github/workflows/auto-updater.yml
+++ b/.github/workflows/auto-updater.yml
@@ -17,6 +17,8 @@ jobs:
         uses: sapphiredev/.github/actions/install-yarn-dependencies@main
         with:
           node-version: 20
+      - name: Build prettier config
+        run: yarn workspace @sapphire/prettier-config build
       - name: Run updater
         run: yarn au:twemojis
       - name: Run prettier on the code


### PR DESCRIPTION
The [Automatic Data Update](https://github.com/sapphiredev/utilities/actions/workflows/auto-updater.yml) workflow currently fails once it tries to format the code. The cause of this failure is due to the prettier config needs to be built/transpiled into JS.

> Error:  Invalid configuration for file "/home/runner/work/utilities/utilities/packages/async-queue/src/index.ts":
Error:  Cannot find module '/home/runner/work/utilities/utilities/packages/prettier-config/dist/index.mjs' imported from /home/runner/work/utilities/utilities/.prettierrc.mjs
Error: Process completed with exit code 2.

As such, I have added a step that will run the build script for the prettier config.