### PR TITLE
fix(discord.js-utilities)!: update the action row component type

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 	"devDependencies": {
 		"@commitlint/cli": "^19.8.0",
 		"@commitlint/config-conventional": "^19.8.0",
-		"@discordjs/collection": "^1.5.3",
 		"@favware/cliff-jumper": "^6.0.0",
 		"@favware/npm-deprecate": "^2.0.0",
 		"@favware/rollup-type-bundler": "^4.0.0",
@@ -35,7 +34,6 @@
 		"@vitest/coverage-v8": "^3.1.1",
 		"concurrently": "^9.1.2",
 		"cz-conventional-changelog": "^3.3.0",
-		"discord-api-types": "^0.37.119",
 		"discord.js": "^14.19.2",
 		"eslint": "^8.57.1",
 		"eslint-config-prettier": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"concurrently": "^9.1.2",
 		"cz-conventional-changelog": "^3.3.0",
 		"discord-api-types": "^0.37.119",
-		"discord.js": "^14.18.0",
+		"discord.js": "^14.19.2",
 		"eslint": "^8.57.1",
 		"eslint-config-prettier": "^10.1.2",
 		"eslint-plugin-prettier": "^5.2.6",

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/PaginatedMessageTypes.ts
@@ -3,7 +3,7 @@ import type {
 	APIActionRowComponent,
 	APIEmbed,
 	APIMessage,
-	APIMessageActionRowComponent,
+	APIComponentInMessageActionRow,
 	ActionRowComponentOptions,
 	ActionRowData,
 	BaseMessageOptions,
@@ -313,14 +313,14 @@ export type PaginatedMessageInteractionUnion = Exclude<CollectedInteraction, Mod
 /**
  * Represents a union type for components in a paginated message.
  * It can be one of the following types:
- * - `JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>`
+ * - `JSONEncodable<APIActionRowComponent<APIComponentInMessageActionRow>>`
  * - `ActionRowData<ActionRowComponentOptions | MessageActionRowComponentBuilder>`
- * - `APIActionRowComponent<APIMessageActionRowComponent>`
+ * - `APIActionRowComponent<APIComponentInMessageActionRow>`
  */
 export type PaginatedMessageComponentUnion =
-	| JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>
+	| JSONEncodable<APIActionRowComponent<APIComponentInMessageActionRow>>
 	| ActionRowData<ActionRowComponentOptions | MessageActionRowComponentBuilder>
-	| APIActionRowComponent<APIMessageActionRowComponent>;
+	| APIActionRowComponent<APIComponentInMessageActionRow>;
 
 /**
  * @internal This is a duplicate of the same interface in `@sapphire/plugin-i18next`

--- a/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessages/utils.ts
@@ -5,7 +5,7 @@ import {
 	ButtonStyle,
 	ComponentType,
 	type APIActionRowComponent,
-	type APIMessageActionRowComponent,
+	type APIComponentInMessageActionRow,
 	type ActionRowComponentOptions,
 	type ButtonComponentData,
 	type ChannelSelectMenuComponentData,
@@ -184,7 +184,7 @@ export function isActionChannelMenu(action: PaginatedMessageAction): action is P
 /**
  * Creates partitioned message rows based on the provided components.
  * @param components The array of MessageActionRowComponentBuilder objects.
- * @returns An array of `APIActionRowComponent<APIMessageActionRowComponent>` objects.
+ * @returns An array of `APIActionRowComponent<APIComponentInMessageActionRow>` objects.
  */
 export function createPartitionedMessageRow(components: MessageActionRowComponentBuilder[]): PaginatedMessageComponentUnion[] {
 	// Partition the components into two groups: buttons and select menus
@@ -217,7 +217,7 @@ export function createPartitionedMessageRow(components: MessageActionRowComponen
 
 	return [...messageActionButtonActionRows, ...selectMenuActionRows, ...messageLinkButtonActionRows].map((actionRow) =>
 		actionRow.toJSON()
-	) as APIActionRowComponent<APIMessageActionRowComponent>[];
+	) as APIActionRowComponent<APIComponentInMessageActionRow>[];
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,7 +6271,6 @@ __metadata:
   dependencies:
     "@commitlint/cli": "npm:^19.8.0"
     "@commitlint/config-conventional": "npm:^19.8.0"
-    "@discordjs/collection": "npm:^1.5.3"
     "@favware/cliff-jumper": "npm:^6.0.0"
     "@favware/npm-deprecate": "npm:^2.0.0"
     "@favware/rollup-type-bundler": "npm:^4.0.0"
@@ -6284,7 +6283,6 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.1.1"
     concurrently: "npm:^9.1.2"
     cz-conventional-changelog: "npm:^3.3.0"
-    discord-api-types: "npm:^0.37.119"
     discord.js: "npm:^14.19.2"
     eslint: "npm:^8.57.1"
     eslint-config-prettier: "npm:^10.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,6 +379,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discordjs/builders@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "@discordjs/builders@npm:1.11.1"
+  dependencies:
+    "@discordjs/formatters": "npm:^0.6.1"
+    "@discordjs/util": "npm:^1.1.1"
+    "@sapphire/shapeshift": "npm:^4.0.0"
+    discord-api-types: "npm:^0.38.1"
+    fast-deep-equal: "npm:^3.1.3"
+    ts-mixer: "npm:^6.0.4"
+    tslib: "npm:^2.6.3"
+  checksum: 10/bb20b2fb2c700af4bbb20862227cc83a9b58fa7fd2738187b704432e0fcf926eaf5dbbaee2fb74849843669aecc38b5a1ecbda1ec4028bf18cf82a7a6b8e45ac
+  languageName: node
+  linkType: hard
+
 "@discordjs/collection@npm:1.5.3, @discordjs/collection@npm:^1.5.3":
   version: 1.5.3
   resolution: "@discordjs/collection@npm:1.5.3"
@@ -402,20 +417,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discordjs/rest@npm:^2.4.3":
-  version: 2.4.3
-  resolution: "@discordjs/rest@npm:2.4.3"
+"@discordjs/formatters@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@discordjs/formatters@npm:0.6.1"
+  dependencies:
+    discord-api-types: "npm:^0.38.1"
+  checksum: 10/131375d851f027381c3386664b7fcbd04eb3af34419fcb7702241f992226db153357fde5a342c0c1ada31b4f068f6c108bbb65c1c8cc70f17a9c7d44f79452c4
+  languageName: node
+  linkType: hard
+
+"@discordjs/rest@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@discordjs/rest@npm:2.5.0"
   dependencies:
     "@discordjs/collection": "npm:^2.1.1"
     "@discordjs/util": "npm:^1.1.1"
     "@sapphire/async-queue": "npm:^1.5.3"
     "@sapphire/snowflake": "npm:^3.5.3"
     "@vladfrangu/async_event_emitter": "npm:^2.4.6"
-    discord-api-types: "npm:^0.37.119"
+    discord-api-types: "npm:^0.38.1"
     magic-bytes.js: "npm:^1.10.0"
     tslib: "npm:^2.6.3"
     undici: "npm:6.21.1"
-  checksum: 10/b26c856ffdf7641629de99bd901d40d70d9d6f6e2593aa49bdc2811714b00c0a9f35483e1d81b3898fdf737dc270df532d2bffc2ac72d54166f74b22c1b92092
+  checksum: 10/61184293512ac048634db7ce0f9ef3ba4635e56b80ec093377ef9fc89c310727f2a1ae04c4170c2968e45e9b12cf72de338c5c7f6b6c7bc3eb37d9d3924f40c6
   languageName: node
   linkType: hard
 
@@ -426,20 +450,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discordjs/ws@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@discordjs/ws@npm:1.2.1"
+"@discordjs/ws@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@discordjs/ws@npm:1.2.2"
   dependencies:
     "@discordjs/collection": "npm:^2.1.0"
-    "@discordjs/rest": "npm:^2.4.3"
+    "@discordjs/rest": "npm:^2.5.0"
     "@discordjs/util": "npm:^1.1.0"
     "@sapphire/async-queue": "npm:^1.5.2"
     "@types/ws": "npm:^8.5.10"
     "@vladfrangu/async_event_emitter": "npm:^2.2.4"
-    discord-api-types: "npm:^0.37.119"
+    discord-api-types: "npm:^0.38.1"
     tslib: "npm:^2.6.2"
     ws: "npm:^8.17.0"
-  checksum: 10/a9fd6836006fcf93ace5dcf49a3e9cd89ae80b5475ea56a10e97ec046ea04182228afe878be242647802f9b151f08490357fa23ff30760d79f3e704b0b8f29d7
+  checksum: 10/1b4b384888540079c138513dc12e99928f0c79d9341291206c26e6ee481e9f6adefcead17f944ea4dc0c4ad179142d0107490a625cb1ba68cc65e7e5cab01eba
   languageName: node
   linkType: hard
 
@@ -3054,23 +3078,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"discord.js@npm:^14.18.0":
-  version: 14.18.0
-  resolution: "discord.js@npm:14.18.0"
+"discord-api-types@npm:^0.38.1":
+  version: 0.38.2
+  resolution: "discord-api-types@npm:0.38.2"
+  checksum: 10/b1096773db12b6f478022b6ec4806226cde1d882f3d273a10eba3f040947c421312629a380fe485117c319d00f222a867c9784b1312df96e4bd964cb9b561102
+  languageName: node
+  linkType: hard
+
+"discord.js@npm:^14.19.2":
+  version: 14.19.2
+  resolution: "discord.js@npm:14.19.2"
   dependencies:
-    "@discordjs/builders": "npm:^1.10.1"
+    "@discordjs/builders": "npm:^1.11.1"
     "@discordjs/collection": "npm:1.5.3"
-    "@discordjs/formatters": "npm:^0.6.0"
-    "@discordjs/rest": "npm:^2.4.3"
+    "@discordjs/formatters": "npm:^0.6.1"
+    "@discordjs/rest": "npm:^2.5.0"
     "@discordjs/util": "npm:^1.1.1"
-    "@discordjs/ws": "npm:^1.2.1"
+    "@discordjs/ws": "npm:^1.2.2"
     "@sapphire/snowflake": "npm:3.5.3"
-    discord-api-types: "npm:^0.37.119"
+    discord-api-types: "npm:^0.38.1"
     fast-deep-equal: "npm:3.1.3"
     lodash.snakecase: "npm:4.1.1"
+    magic-bytes.js: "npm:^1.10.0"
     tslib: "npm:^2.6.3"
     undici: "npm:6.21.1"
-  checksum: 10/b215624a996439c6c527a3980b255501010f4b787a51674ae76ccb3858b3a3cc669bc96608a3b12028a2e65d81a6d1bc6cc8a2dd663c85bc3e35a87a623e89b4
+  checksum: 10/a000060e14f7f1aa3b4a0410948805f1684f6ebc1159bfec59069f9f59ebd301dc3e7ac7a7f85d9985e9ce9e807796c0b433b71c328c12902acee61363393fc4
   languageName: node
   linkType: hard
 
@@ -6253,7 +6285,7 @@ __metadata:
     concurrently: "npm:^9.1.2"
     cz-conventional-changelog: "npm:^3.3.0"
     discord-api-types: "npm:^0.37.119"
-    discord.js: "npm:^14.18.0"
+    discord.js: "npm:^14.19.2"
     eslint: "npm:^8.57.1"
     eslint-config-prettier: "npm:^10.1.2"
     eslint-plugin-prettier: "npm:^5.2.6"


### PR DESCRIPTION
Discord.js 14.19.x utilises [discord-api-types #1190](https://github.com/discordjs/discord-api-types/pull/1190) of which includes a breaking change that renamed `APIMessageActionRowComponent` to `APIComponentInMessageActionRow`. Due to this, I have marked this PR as a breaking change for `discord.js-utilities`. 

Additionally, I have removed `discord-api-types` and `@discordjs/collection` from dev deps so that the versions that discord.js installs can be used instead. This is a change that the d.js docs "subpackages" tag suggests:
> discord.js includes multiple sub-packages, installing these separately can mess with internal code:
> ```
> npm uninstall discord-api-types @discordjs/rest @discordjs/builders
> yarn remove discord-api-types @discordjs/rest @discordjs/builders
> pnpm remove discord-api-types @discordjs/rest @discordjs/builders
> ```

Fixes https://github.com/sapphiredev/cli/issues/386