### PR TITLE
fix(makeobject): resolve prototype pollution

### DIFF
--- a/packages/utilities/src/lib/makeObject.ts
+++ b/packages/utilities/src/lib/makeObject.ts
@@ -5,7 +5,7 @@
  * @param obj The object to edit
  * @throws If the path contains a segment that can mutate an object's prototype.
  */
-export function makeObject(path: string, value: unknown, obj: Record<string, unknown> = {}): Record<string, unknown> {
+export function makeObject(path: string, value: unknown, obj: Record<string, unknown> = Object.create(null)): Record<string, unknown> {
 	const route = path.split('.');
 	if (route.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) {
 		throw new TypeError('path cannot contain __proto__, constructor, or prototype');
@@ -15,7 +15,7 @@ export function makeObject(path: string, value: unknown, obj: Record<string, unk
 		const lastKey = route.pop() as string;
 		let reference = obj;
 		for (const key of route) {
-			if (!Object.prototype.hasOwnProperty.call(reference, key) || !reference[key]) reference[key] = {};
+			if (!Object.prototype.hasOwnProperty.call(reference, key) || !reference[key]) reference[key] = Object.create(null);
 			reference = reference[key] as Record<string, unknown>;
 		}
 		reference[lastKey] = value;

--- a/packages/utilities/src/lib/makeObject.ts
+++ b/packages/utilities/src/lib/makeObject.ts
@@ -3,14 +3,19 @@
  * @param path The dotted path
  * @param value The value
  * @param obj The object to edit
+ * @throws If the path contains a segment that can mutate an object's prototype.
  */
 export function makeObject(path: string, value: unknown, obj: Record<string, unknown> = {}): Record<string, unknown> {
+	const route = path.split('.');
+	if (route.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) {
+		throw new TypeError('path cannot contain __proto__, constructor, or prototype');
+	}
+
 	if (path.includes('.')) {
-		const route = path.split('.');
 		const lastKey = route.pop() as string;
 		let reference = obj;
 		for (const key of route) {
-			if (!reference[key]) reference[key] = {};
+			if (!Object.prototype.hasOwnProperty.call(reference, key) || !reference[key]) reference[key] = {};
 			reference = reference[key] as Record<string, unknown>;
 		}
 		reference[lastKey] = value;

--- a/packages/utilities/src/lib/makeObject.ts
+++ b/packages/utilities/src/lib/makeObject.ts
@@ -2,7 +2,8 @@
  * Turn a dotted path into a json object.
  * @param path The dotted path
  * @param value The value
- * @param obj The object to edit
+ * @param obj The object to edit. Defaults to a null prototype object.
+ * @returns The object with the value set at the path.
  * @throws If the path contains a segment that can mutate an object's prototype.
  */
 export function makeObject(path: string, value: unknown, obj: Record<string, unknown> = Object.create(null)): Record<string, unknown> {

--- a/packages/utilities/tests/makeObject.test.ts
+++ b/packages/utilities/tests/makeObject.test.ts
@@ -20,4 +20,23 @@ describe('makeObject', () => {
 		const made = makeObject('he.wor', 'ld', { he: { llo: 'world' } });
 		expect(made).toEqual({ he: { llo: 'world', wor: 'ld' } });
 	});
+
+	test.each(['__proto__.polluted', 'constructor.prototype.polluted', 'safe.prototype.polluted'])(
+		'GIVEN path containing reserved segment %s THEN throws without polluting prototypes',
+		(path) => {
+			const object = {};
+
+			expect(() => makeObject(path, true, object)).toThrowError(new TypeError('path cannot contain __proto__, constructor, or prototype'));
+			expect(Object.prototype).not.toHaveProperty('polluted');
+			expect(object).toEqual({});
+		}
+	);
+
+	test('GIVEN inherited path segment THEN creates an own object', () => {
+		const made = makeObject('toString.polluted', true);
+
+		expect(made).toEqual({ toString: { polluted: true } });
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		expect(Object.prototype.toString).not.toHaveProperty('polluted');
+	});
 });


### PR DESCRIPTION
## Summary 🔒

Prevents prototype pollution in `makeObject` following the reported security advisory.[^report]

> [!IMPORTANT]
> `makeObject` now throws a `TypeError` when a path contains `__proto__`, `constructor`, or `prototype`.

## Changes 🛠️

- Reject prototype-mutating path segments before modifying the target object.
- Traverse only own properties so inherited built-ins cannot be modified.
- Add regression coverage for reserved and inherited path segments.

[^report]: https://gist.github.com/Ridwan-AI/908fb64bfc87b09c0e3acdf2f9fd650e

---

## Squash-Merge Commit

```text
fix(makeobject): prevent prototype pollution

Reject prototype-mutating path segments and only traverse own properties.
Add regression coverage for reserved and inherited path segments.
```